### PR TITLE
`PageTitle` breadcrumbs tweaks

### DIFF
--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -59,7 +59,7 @@ const crumbs: Crumb[] = [
 	...ancestors,
 ]
 
-const showBreadcrumbs = ancestors.length > 0
+const showBreadcrumbs = currentPath !== '/'
 ---
 
 {showBreadcrumbs && (


### PR DESCRIPTION
Adds all non-home ancestors to breadcrumb navigation.