### PR TITLE
Progress tracking — auth, database & per-user completion tracking

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ Knowledge base built with Astro Starlight. Full spec in [SPEC.md](SPEC.md).
 
 - **Package manager**: pnpm
 - **Language**: TypeScript (strict mode)
-- **Framework**: Astro 5 + Starlight + Solid.js 1.x
+- **Framework**: Astro 6 + Starlight + Solid.js 1.x
 - **Linting/Formatting**: Ultracite (Biome)
 - **Locale**: Czech (`cs`) — root locale, no multilingual setup
 

--- a/.claude/SPEC-PROGRESS-TRACKING.md
+++ b/.claude/SPEC-PROGRESS-TRACKING.md
@@ -1,0 +1,324 @@
+# Progress Tracking
+
+Builds on Subject Overview feature. Adds authentication, database, and per-user progress tracking.
+
+## Overview
+
+Parents can log in with Google and mark topic-grade pairs as completed. Progress is visible on the subject-level Přehled pages in both card and table views. Table view allows managing progress via checkboxes.
+
+## Stack Additions (on top of Subject Overview)
+
+- **Auth**: Better Auth (Google OAuth)
+- **ORM**: Drizzle (SQLite dialect)
+- **Database**: Cloudflare D1
+- **Data fetching**: TanStack Query (`@tanstack/solid-query`)
+- **Astro mode**: Server (static by default, server-rendered API routes only)
+
+---
+
+## Database Schema (Drizzle)
+
+```typescript
+// src/db/schema.ts
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+
+// Better Auth manages these tables (auto-generated via CLI):
+// - user
+// - session
+// - account
+// - verification
+
+// Our table:
+export const userProgress = sqliteTable('user_progress', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  userId: text('user_id').notNull(),
+  slug: text('slug').notNull(),           // e.g. "matematika/01-pocetni-operace/6-rocnik"
+  completed: integer('completed', { mode: 'boolean' }).notNull().default(false),
+  updatedAt: integer('updated_at', { mode: 'timestamp' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+// Unique constraint: one row per user + slug
+// CREATE UNIQUE INDEX idx_user_slug ON user_progress(user_id, slug);
+```
+
+### Slug convention
+
+Mirrors the content directory path: `{subject}/{topic-dir}/{grade}`
+
+Examples:
+
+```
+cesky-jazyk/01-rozlisuje-subjektivni-a-hodnotici-sdeleni/6-rocnik
+matematika/15-pythagorova-veta/8-rocnik
+ja-a-svet/42-anticke-recko/7-rocnik
+```
+
+### Query patterns (plain English)
+
+- **"Get all of Jan's math progress"** — find every row for this user where slug starts with `matematika/`. Powers the Přehled page on load.
+- **"Get Jan's math progress for 7th grade only"** — same, but slug must also end with `/7-rocnik`. Used when grade filter is active.
+- **"Jan clicked a checkbox"** — insert a new row, or update the existing one if it already exists (upsert). One write per click.
+
+---
+
+## API Routes
+
+All under `src/pages/api/`. These are the only server-rendered endpoints. API route files must NOT export `prerender`.
+
+### `src/pages/api/auth/[...all].ts`
+
+Better Auth catch-all handler. Manages OAuth flow, sessions, callbacks.
+
+```typescript
+import { auth } from '@/lib/auth';
+import type { APIRoute } from 'astro';
+
+export const ALL: APIRoute = async (ctx) => {
+  return auth.handler(ctx.request);
+};
+```
+
+### `src/pages/api/progress.ts`
+
+**GET** `?subject=matematika` or `?subject=matematika&grade=7-rocnik`
+
+Returns `{ [slug]: boolean }` map for the authenticated user.
+
+**POST** `{ slug: string, completed: boolean }`
+
+Upserts a single progress entry. Returns the updated row.
+
+Both return `401` if not authenticated.
+
+---
+
+## Auth
+
+### `src/lib/auth.ts` (server)
+
+```typescript
+import { betterAuth } from 'better-auth';
+import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { db } from '@/db';
+
+export const auth = betterAuth({
+  database: drizzleAdapter(db, { provider: 'sqlite' }),
+  socialProviders: {
+    google: {
+      clientId: import.meta.env.GOOGLE_CLIENT_ID,
+      clientSecret: import.meta.env.GOOGLE_CLIENT_SECRET,
+    },
+  },
+});
+```
+
+### `src/lib/auth-client.ts` (client)
+
+```typescript
+import { createAuthClient } from 'better-auth/client';
+
+export const authClient = createAuthClient();
+```
+
+---
+
+## Data Fetching (TanStack Query)
+
+`@tanstack/solid-query` handles progress data fetching, caching, and mutations.
+
+### Progress query
+
+```typescript
+const progress = createQuery(() => ({
+  queryKey: ['progress', subject],
+  queryFn: () => fetch(`/api/progress?subject=${subject}`).then(r => r.json()),
+  enabled: !!session(),   // only fetch when authenticated
+}));
+```
+
+Provides built-in loading and error states. Caches results — navigating away and back serves from cache without refetching.
+
+### Toggle mutation
+
+```typescript
+const toggle = createMutation(() => ({
+  mutationFn: (data: { slug: string; completed: boolean }) =>
+    fetch('/api/progress', { method: 'POST', body: JSON.stringify(data) }),
+  onMutate: async (data) => {
+    // optimistic update: toggle checkbox immediately
+  },
+  onError: (err, data, context) => {
+    // revert on failure, show toast
+  },
+  onSettled: () => {
+    // refetch to ensure consistency
+  },
+}));
+```
+
+Handles optimistic updates, error rollback, and deduplication (prevents panic-clicking from firing duplicate requests).
+
+### Provider setup
+
+`QueryClientProvider` wraps the `SubjectOverview` component:
+
+```typescript
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
+
+const queryClient = new QueryClient();
+
+// in SubjectOverview.tsx
+<QueryClientProvider client={queryClient}>
+  {/* GradeFilter, ViewToggle, CardView, TableView */}
+</QueryClientProvider>
+```
+
+---
+
+## UI Changes (on top of Subject Overview components)
+
+### `UserMenu.tsx` (new)
+
+- Lives in the Starlight header (via component override).
+- Not authenticated: shows "Přihlásit se" — click triggers `authClient.signIn.social({ provider: 'google' })`.
+- Authenticated: shows user avatar/name and "Odhlásit" button.
+- Mobile layout: will require prototyping — Starlight's mobile header is tight.
+
+### `SubjectOverview.tsx` (updated)
+
+- Wraps children in `QueryClientProvider`.
+- On mount: checks auth state via `authClient.useSession()`.
+- If authenticated: progress data is fetched via TanStack Query (`createQuery`).
+- If not authenticated: renders views without progress data (same as Subject Overview).
+- Passes progress data down to CardView and TableView.
+
+### `CardView.tsx` (updated)
+
+- When authenticated and progress data is available, cards show a completion indicator (emoji/checkmark + CSS class).
+- Completion logic (binary, no partial indicators):
+  - Specific grade selected (e.g. "6") → checkmark if that topic-grade is completed.
+  - "Vše" selected → checkmark only if ALL available grades for that topic are completed.
+- When not authenticated: no indicators (same as Subject Overview).
+
+### `TableView.tsx` (updated)
+
+- Grade columns remain muted (not hidden) per Subject Overview behavior.
+- When authenticated: grade cells show checkboxes instead of plain links. Checked = completed.
+- Clicking a checkbox: triggers `createMutation` — optimistic toggle, POST in background, revert on error.
+- Error handling: toast/snackbar notification on failure. Toast implementation TBD (library vs custom).
+- When not authenticated: cells show links only (same as Subject Overview).
+
+### `Toast.tsx` (new)
+
+- Simple notification component for error states.
+- Implementation approach TBD (library vs custom).
+
+---
+
+## Astro Configuration Changes
+
+```typescript
+// astro.config.mjs — update for server mode + CF adapter
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+  output: 'server',              // static by default, server-rendered API routes only
+  adapter: cloudflare({
+    platformProxy: { enabled: true },
+  }),
+  integrations: [
+    starlight({ /* existing config */ }),
+    solidJs(),
+  ],
+});
+```
+
+All content pages remain prerendered (default in server mode). Only `src/pages/api/` routes are server-rendered.
+
+---
+
+## File Structure (New/Changed from Subject Overview)
+
+```
+src/
+├── db/
+│   ├── index.ts                 # Drizzle client (D1 binding)
+│   └── schema.ts                # Drizzle schema
+├── lib/
+│   ├── auth.ts                  # Better Auth server config
+│   └── auth-client.ts           # Better Auth client
+├── pages/
+│   └── api/
+│       ├── auth/
+│       │   └── [...all].ts      # Better Auth catch-all
+│       └── progress.ts          # GET/POST progress
+├── components/
+│   ├── subject-overview/
+│   │   └── SubjectOverview.tsx
+│   ├── card-view/
+│   │   └── CardView.tsx
+│   ├── table-view/
+│   │   └── TableView.tsx
+│   ├── grade-filter/
+│   ├── view-toggle/
+│   ├── user-menu/
+│   │   └── UserMenu.tsx
+│   └── toast/
+│       └── Toast.tsx
+drizzle/
+├── migrations/                   # Generated by drizzle-kit
+└── drizzle.config.ts
+wrangler.jsonc                    # update with D1 binding
+```
+
+---
+
+## Environment Variables
+
+```env
+# Better Auth
+BETTER_AUTH_SECRET=<random-32-char-string>
+BETTER_AUTH_URL=https://semafor.sklar.workers.dev
+
+# Google OAuth
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+```
+
+D1 binding is configured in `wrangler.jsonc`, not via env vars.
+
+---
+
+## Accessibility
+
+All interactive elements must be keyboard-navigable and screen-reader friendly. Specific ARIA patterns will be determined during implementation.
+
+---
+
+## Testing
+
+Testing strategy and tooling to be decided during implementation. Tests are a deliverable, not optional.
+
+- **Unit tests**: progress fetch/upsert logic, auth state handling, completion indicator logic (card: all-grades-done check, table: checkbox toggle + optimistic revert).
+- **E2E tests**: full login flow (Google OAuth), mark topic as completed → refresh → verify persistence, toggle checkbox → simulate API error → verify revert + toast.
+- **API mocking**: MSW (Mock Service Worker) for mocking `/api/progress` and `/api/auth` endpoints in tests without hitting real services.
+
+---
+
+## Edge Cases
+
+- **Topics with fewer grades** (e.g. Chemistry: only 8-9): `grades` array in props controls which columns have checkboxes. Missing grades show "—", no checkbox.
+- **No JS**: pages render as static Starlight content. Solid components don't mount. Progress tracking is progressive enhancement.
+- **Concurrent edits**: last write wins. At 3-10 users with separate accounts, conflicts are impossible.
+- **Session expiry**: if POST returns 401, show a toast and refresh auth state.
+
+---
+
+## What's Next
+
+- Microsoft OAuth (few lines of Better Auth config).
+- Dashboard / aggregate progress views across subjects.
+- Skeleton loaders for progress data loading.
+- Motion / animation library for micro-interactions and transitions.

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,19 @@
+# Astro
+# Canonical site URL for sitemaps and OG tags
 SITE_URL=
+
+# Better Auth
+# Session signing key (generate: openssl rand -base64 32)
+BETTER_AUTH_SECRET=
+
+# Better Auth
+# Canonical app URL for OAuth callbacks
+BETTER_AUTH_URL=
+
+# Google OAuth
+# https://console.cloud.google.com/apis/credentials
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Analytics website ID (optional)
 UMAMI_WEBSITE_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,7 @@ node_modules
 Thumbs.db
 
 # tests
+__screenshots__
+.vitest-attachments
 playwright-report
 test-results

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ node_modules
 
 # framework
 .astro
+.wrangler
 
 # logs
 *-debug.log*
@@ -32,6 +33,6 @@ node_modules
 .DS_Store
 Thumbs.db
 
-# playwright
+# tests
 playwright-report
 test-results

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,62 @@
+# Local Development Setup
+
+## 🌳 Environment Variables
+
+Copy the example file and fill in the values:
+
+```sh
+cp .env.example .env
+```
+
+| Variable | Required | How to get |
+|----------|----------|------------|
+| `SITE_URL` | no | `http://localhost:4321` for local dev |
+| `BETTER_AUTH_SECRET` | yes | `openssl rand -base64 32` |
+| `BETTER_AUTH_URL` | yes | `http://localhost:4321` for local dev |
+| `GOOGLE_CLIENT_ID` | yes | Google Cloud Console (see below) |
+| `GOOGLE_CLIENT_SECRET` | yes | Google Cloud Console (see below) |
+| `UMAMI_WEBSITE_ID` | no | Umami analytics dashboard |
+
+Without auth variables the site still runs — auth features hide themselves gracefully.
+
+## 💂‍♂️ Google OAuth Credentials
+
+> [!IMPORTANT]
+> These credentials are for local development only. You can always view/regenerate them in the Console later. For production, create a separate OAuth client with the production redirect URI and store secrets via `wrangler secret put`.
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com)
+2. Create a new project (e.g. `Semafor local`) or select an existing one
+3. Navigate to **APIs & Services > OAuth consent screen**
+   - Choose **External** user type
+   - Fill in app name, support email and developer contact
+   - Skip scopes (defaults are fine)
+   - Add your Google email under **Test users**<br />
+	 (only listed users can sign in while app is in _Testing status_)
+4. Navigate to **APIs & Services > Credentials**
+   - Click **Create Credentials > OAuth client ID**
+   - Choose **Web application** app type
+   - Add authorized redirect URI: `http://localhost:4321/api/auth/callback/google`
+5. Copy **Client ID** and **Client Secret** into your `.env`
+
+
+## 🗄️ D1 Database (Local)
+
+The Cloudflare adapter's `platformProxy` option creates a local SQLite-backed D1 automatically. Apply migrations:
+
+```sh
+wrangler d1 migrations apply semafor-db --local
+```
+
+## 🔐 Production Secrets (Cloudflare)
+
+When deploying, store secrets via Wrangler:
+
+```sh
+wrangler secret put BETTER_AUTH_SECRET
+wrangler secret put BETTER_AUTH_URL
+wrangler secret put GOOGLE_CLIENT_ID
+wrangler secret put GOOGLE_CLIENT_SECRET
+```
+
+Create a separate Google OAuth client with your production redirect URI:
+`https://<your-domain>/api/auth/callback/google`

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -33,6 +33,26 @@ export default defineConfig({
 	site,
 	env: {
 		schema: {
+			BETTER_AUTH_SECRET: envField.string({
+				context: 'server',
+				access: 'secret',
+				optional: true,
+			}),
+			BETTER_AUTH_URL: envField.string({
+				context: 'server',
+				access: 'secret',
+				optional: true,
+			}),
+			GOOGLE_CLIENT_ID: envField.string({
+				context: 'server',
+				access: 'secret',
+				optional: true,
+			}),
+			GOOGLE_CLIENT_SECRET: envField.string({
+				context: 'server',
+				access: 'secret',
+				optional: true,
+			}),
 			UMAMI_WEBSITE_ID: envField.string({
 				context: 'client',
 				access: 'public',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,6 +27,7 @@ const analyticsHead =
 export default defineConfig({
 	output: 'server',
 	adapter: cloudflare({
+		imageService: 'passthrough',
 		platformProxy: { enabled: true },
 		prerenderEnvironment: 'node',
 	}),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -116,6 +116,7 @@ export default defineConfig({
 			// overrrides for default components and styles
 			components: {
 				Footer: './src/components/Footer.astro',
+				Header: './src/components/Header.astro',
 				Hero: './src/components/Hero.astro',
 				PageTitle: './src/components/PageTitle.astro',
 				Sidebar: './src/components/Sidebar.astro',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,9 @@
-// @ts-check
+import cloudflare from '@astrojs/cloudflare'
 import solidJs from '@astrojs/solid-js'
 import starlight from '@astrojs/starlight'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig, envField } from 'astro/config'
+import { starlightCloudflareCompat } from './src/plugins/starlight-cloudflare-compat'
 import { sidebar } from './src/sidebar.config'
 
 const site = process.env.SITE_URL
@@ -24,6 +25,11 @@ const analyticsHead =
 
 // https://astro.build/config
 export default defineConfig({
+	output: 'server',
+	adapter: cloudflare({
+		platformProxy: { enabled: true },
+		prerenderEnvironment: 'node',
+	}),
 	site,
 	env: {
 		schema: {
@@ -34,7 +40,7 @@ export default defineConfig({
 			}),
 		},
 	},
-	vite: { plugins: [tailwindcss()] },
+	vite: { plugins: [tailwindcss(), starlightCloudflareCompat()] },
 	experimental: {
 		rustCompiler: true,
 		queuedRendering: { enabled: true },

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+	schema: './src/db/schema.ts',
+	out: './drizzle/migrations',
+	dialect: 'sqlite',
+})

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'drizzle-kit'
 
 export default defineConfig({
-	schema: './src/db/schema.ts',
+	schema: ['./src/db/schema.ts', './src/db/auth-schema.ts'],
 	out: './drizzle/migrations',
 	dialect: 'sqlite',
 })

--- a/drizzle/migrations/0000_yellow_the_renegades.sql
+++ b/drizzle/migrations/0000_yellow_the_renegades.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `user_progress` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`slug` text NOT NULL,
+	`completed` integer DEFAULT false NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_user_slug` ON `user_progress` (`user_id`,`slug`);

--- a/drizzle/migrations/0001_amusing_dracula.sql
+++ b/drizzle/migrations/0001_amusing_dracula.sql
@@ -1,0 +1,49 @@
+CREATE TABLE `account` (
+	`id` text PRIMARY KEY NOT NULL,
+	`account_id` text NOT NULL,
+	`provider_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`access_token` text,
+	`refresh_token` text,
+	`id_token` text,
+	`access_token_expires_at` integer,
+	`refresh_token_expires_at` integer,
+	`scope` text,
+	`password` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `session` (
+	`id` text PRIMARY KEY NOT NULL,
+	`expires_at` integer NOT NULL,
+	`token` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`ip_address` text,
+	`user_agent` text,
+	`user_id` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `session_token_unique` ON `session` (`token`);--> statement-breakpoint
+CREATE TABLE `user` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`email` text NOT NULL,
+	`email_verified` integer DEFAULT false NOT NULL,
+	`image` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_email_unique` ON `user` (`email`);--> statement-breakpoint
+CREATE TABLE `verification` (
+	`id` text PRIMARY KEY NOT NULL,
+	`identifier` text NOT NULL,
+	`value` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer,
+	`updated_at` integer
+);

--- a/drizzle/migrations/meta/0000_snapshot.json
+++ b/drizzle/migrations/meta/0000_snapshot.json
@@ -1,0 +1,70 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "84295756-4e37-4628-b08e-7d24994a4cd1",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "user_progress": {
+      "name": "user_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_slug": {
+          "name": "idx_user_slug",
+          "columns": ["user_id", "slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/0001_snapshot.json
+++ b/drizzle/migrations/meta/0001_snapshot.json
@@ -1,0 +1,381 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "95ebafb8-7eca-4615-9575-74f1fbc3c4ba",
+  "prevId": "84295756-4e37-4628-b08e-7d24994a4cd1",
+  "tables": {
+    "user_progress": {
+      "name": "user_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_slug": {
+          "name": "idx_user_slug",
+          "columns": ["user_id", "slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1774193083494,
+      "tag": "0000_yellow_the_renegades",
+      "breakpoints": true
+    }
+  ]
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1774193083494,
       "tag": "0000_yellow_the_renegades",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1774199707873,
+      "tag": "0001_amusing_dracula",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@astrojs/starlight-tailwind": "5.0.0",
     "@tailwindcss/vite": "4.1.18",
     "astro": "6.0.8",
+    "better-auth": "1.5.6",
     "drizzle-orm": "0.45.1",
     "sharp": "0.34.5",
     "solid-js": "1.9.11",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@astrojs/check": "0.9.8",
+    "@astrojs/cloudflare": "13.1.3",
     "@astrojs/compiler-rs": "0.1.6",
     "@astrojs/solid-js": "6.0.1",
     "@astrojs/starlight": "0.38.2",
@@ -41,7 +42,7 @@
     "@vitest/browser-playwright": "4.1.0",
     "vite-plugin-solid": "2.11.11",
     "vitest": "4.1.0",
-    "wrangler": "4.72.0"
+    "wrangler": "4.76.0"
   },
   "engines": {
     "node": "24.14.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@astrojs/starlight": "0.38.2",
     "@astrojs/starlight-tailwind": "5.0.0",
     "@tailwindcss/vite": "4.1.18",
+    "@tanstack/solid-query": "5.95.0",
     "astro": "6.0.8",
     "better-auth": "1.5.6",
     "drizzle-orm": "0.45.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@astrojs/starlight-tailwind": "5.0.0",
     "@tailwindcss/vite": "4.1.18",
     "astro": "6.0.8",
+    "drizzle-orm": "0.45.1",
     "sharp": "0.34.5",
     "solid-js": "1.9.11",
     "tailwindcss": "4.1.18",
@@ -40,6 +41,7 @@
     "@playwright/test": "1.58.2",
     "@solidjs/testing-library": "0.8.10",
     "@vitest/browser-playwright": "4.1.0",
+    "drizzle-kit": "0.31.10",
     "vite-plugin-solid": "2.11.11",
     "vitest": "4.1.0",
     "wrangler": "4.76.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,25 +13,28 @@ importers:
         version: 0.9.8(prettier@3.8.1)(typescript@5.9.3)
       '@astrojs/cloudflare':
         specifier: 13.1.3
-        version: 13.1.3(@types/node@24.12.0)(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.30.2)(workerd@1.20260317.1)(wrangler@4.76.0)(yaml@2.8.2)
+        version: 13.1.3(@types/node@24.12.0)(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(workerd@1.20260317.1)(wrangler@4.76.0)(yaml@2.8.2)
       '@astrojs/compiler-rs':
         specifier: 0.1.6
         version: 0.1.6
       '@astrojs/solid-js':
         specifier: 6.0.1
-        version: 6.0.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(solid-js@1.9.11)(yaml@2.8.2)
+        version: 6.0.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(solid-js@1.9.11)(tsx@4.21.0)(yaml@2.8.2)
       '@astrojs/starlight':
         specifier: 0.38.2
-        version: 0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))
+        version: 0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@astrojs/starlight-tailwind':
         specifier: 5.0.0
-        version: 5.0.0(@astrojs/starlight@0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.1.18)
+        version: 5.0.0(@astrojs/starlight@0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.1.18)
       '@tailwindcss/vite':
         specifier: 4.1.18
-        version: 4.1.18(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 4.1.18(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       astro:
         specifier: 6.0.8
-        version: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)
+        version: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      drizzle-orm:
+        specifier: 0.45.1
+        version: 0.45.1
       sharp:
         specifier: 0.34.5
         version: 0.34.5
@@ -59,13 +62,16 @@ importers:
         version: 0.8.10(solid-js@1.9.11)
       '@vitest/browser-playwright':
         specifier: 4.1.0
-        version: 4.1.0(playwright@1.58.2)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.1.0)
+        version: 4.1.0(playwright@1.58.2)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+      drizzle-kit:
+        specifier: 0.31.10
+        version: 0.31.10
       vite-plugin-solid:
         specifier: 2.11.11
-        version: 2.11.11(solid-js@1.9.11)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 2.11.11(solid-js@1.9.11)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       wrangler:
         specifier: 4.76.0
         version: 4.76.0
@@ -479,6 +485,9 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
 
@@ -509,16 +518,54 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.3':
@@ -527,16 +574,52 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.3':
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.3':
@@ -545,10 +628,34 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.3':
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -557,10 +664,34 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.3':
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.3':
@@ -569,10 +700,34 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.3':
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.3':
@@ -581,10 +736,34 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.3':
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -593,10 +772,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.3':
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.3':
@@ -605,16 +808,46 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.3':
     resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.3':
@@ -623,10 +856,28 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -635,11 +886,29 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
@@ -647,16 +916,52 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.3':
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.3':
@@ -1480,6 +1785,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   caniuse-lite@1.0.30001779:
     resolution: {integrity: sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==}
 
@@ -1652,6 +1960,102 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.1:
+    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
@@ -1688,6 +2092,16 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -1782,6 +2196,9 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -2495,6 +2912,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
 
@@ -2579,6 +2999,13 @@ packages:
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -2692,6 +3119,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typesafe-path@0.2.2:
     resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
@@ -3196,15 +3628,15 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@13.1.3(@types/node@24.12.0)(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.30.2)(workerd@1.20260317.1)(wrangler@4.76.0)(yaml@2.8.2)':
+  '@astrojs/cloudflare@13.1.3(@types/node@24.12.0)(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(workerd@1.20260317.1)(wrangler@4.76.0)(yaml@2.8.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
       '@astrojs/underscore-redirects': 1.0.2
-      '@cloudflare/vite-plugin': 1.30.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(workerd@1.20260317.1)(wrangler@4.76.0)
-      astro: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)
+      '@cloudflare/vite-plugin': 1.30.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260317.1)(wrangler@4.76.0)
+      astro: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       piccolore: 0.1.3
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       wrangler: 4.76.0
     transitivePeerDependencies:
       - '@types/node'
@@ -3325,12 +3757,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))':
+  '@astrojs/mdx@5.0.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 7.0.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -3354,11 +3786,11 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/solid-js@6.0.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(solid-js@1.9.11)(yaml@2.8.2)':
+  '@astrojs/solid-js@6.0.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(solid-js@1.9.11)(tsx@4.21.0)(yaml@2.8.2)':
     dependencies:
       solid-js: 1.9.11
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
-      vite-plugin-solid: 2.11.11(solid-js@1.9.11)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite-plugin-solid: 2.11.11(solid-js@1.9.11)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - '@types/node'
@@ -3374,22 +3806,22 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.1.18)':
+  '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.1.18)':
     dependencies:
-      '@astrojs/starlight': 0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))
+      '@astrojs/starlight': 0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       tailwindcss: 4.1.18
 
-  '@astrojs/starlight@0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))':
+  '@astrojs/starlight@0.38.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 7.0.1
-      '@astrojs/mdx': 5.0.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))
+      '@astrojs/mdx': 5.0.2(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@astrojs/sitemap': 3.7.1
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)
-      astro-expressive-code: 0.41.6(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))
+      astro: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro-expressive-code: 0.41.6(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -3609,12 +4041,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260317.1
 
-  '@cloudflare/vite-plugin@1.30.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(workerd@1.20260317.1)(wrangler@4.76.0)':
+  '@cloudflare/vite-plugin@1.30.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260317.1)(wrangler@4.76.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
       miniflare: 4.20260317.1
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       wrangler: 4.76.0
       ws: 8.18.0
     transitivePeerDependencies:
@@ -3673,6 +4105,8 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@emmetio/abbreviation@2.3.3':
     dependencies:
       '@emmetio/scanner': 1.0.4
@@ -3712,79 +4146,233 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.13.6
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
@@ -4241,12 +4829,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4336,29 +4924,29 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitest/browser-playwright@4.1.0(playwright@1.58.2)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.1.0)':
+  '@vitest/browser-playwright@4.1.0(playwright@1.58.2)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)':
     dependencies:
-      '@vitest/browser': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.1.0)
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/browser': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      vitest: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.1.0)':
+  '@vitest/browser@4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.1.0
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      vitest: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -4375,13 +4963,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -4503,12 +5091,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.6(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)):
+  astro-expressive-code@0.41.6(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)):
     dependencies:
-      astro: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       rehype-expressive-code: 0.41.6
 
-  astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2):
+  astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
@@ -4560,8 +5148,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.4
       vfile: 6.0.3
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -4648,6 +5236,8 @@ snapshots:
       electron-to-chromium: 1.5.313
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-from@1.1.2: {}
 
   caniuse-lite@1.0.30001779: {}
 
@@ -4794,6 +5384,15 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.21.0
+
+  drizzle-orm@0.45.1: {}
+
   dset@3.1.4: {}
 
   electron-to-chromium@1.5.313: {}
@@ -4831,6 +5430,60 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -4940,6 +5593,10 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-slugger@2.0.0: {}
 
@@ -6103,6 +6760,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   retext-latin@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -6265,6 +6924,13 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
@@ -6362,6 +7028,13 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
 
   typesafe-path@0.2.2: {}
 
@@ -6481,7 +7154,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@2.11.11(solid-js@1.9.11)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
+  vite-plugin-solid@2.11.11(solid-js@1.9.11)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -6489,12 +7162,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.11
       solid-refresh: 0.6.3(solid-js@1.9.11)
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.1(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
+  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6507,20 +7180,21 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vitefu@1.1.1(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
+  vitefu@1.1.1(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitefu@1.1.2(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
+  vitefu@1.1.2(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
+  vitest@4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -6537,11 +7211,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
-      '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.1.0)
+      '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       jsdom: 29.0.0
     transitivePeerDependencies:
       - msw

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@tanstack/solid-query':
+        specifier: 5.95.0
+        version: 5.95.0(solid-js@1.9.11)
       astro:
         specifier: 6.0.8
         version: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1625,6 +1628,14 @@ packages:
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/query-core@5.95.0':
+    resolution: {integrity: sha512-H1/CWCe8tGL3YIVeo770Z6kPbt0B3M1d/iQXIIK1qlFiFt6G2neYdkHgLapOC8uMYNt9DmHjmGukEKgdMk1P+A==}
+
+  '@tanstack/solid-query@5.95.0':
+    resolution: {integrity: sha512-h0boybHdi6fPoSho8onCw0Sac2ahl4TKxgcgzuB4Vd0OGUrFNTEyi3qkN5KllAtny6WtCXVrMJMUuUd0C7NTtw==}
+    peerDependencies:
+      solid-js: ^1.6.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5078,6 +5089,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@tanstack/query-core@5.95.0': {}
+
+  '@tanstack/solid-query@5.95.0(solid-js@1.9.11)':
+    dependencies:
+      '@tanstack/query-core': 5.95.0
+      solid-js: 1.9.11
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/check':
         specifier: 0.9.8
         version: 0.9.8(prettier@3.8.1)(typescript@5.9.3)
+      '@astrojs/cloudflare':
+        specifier: 13.1.3
+        version: 13.1.3(@types/node@24.12.0)(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.30.2)(workerd@1.20260317.1)(wrangler@4.76.0)(yaml@2.8.2)
       '@astrojs/compiler-rs':
         specifier: 0.1.6
         version: 0.1.6
@@ -64,8 +67,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       wrangler:
-        specifier: 4.72.0
-        version: 4.72.0
+        specifier: 4.76.0
+        version: 4.76.0
 
 packages:
 
@@ -85,6 +88,12 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
+
+  '@astrojs/cloudflare@13.1.3':
+    resolution: {integrity: sha512-6QkD4ZKSbXaSwojTF5S5H8dVaGlTyeAJm6aA+XpbjQDGXLr/4Mqftm8bC3M3LQgefQoQmxHViIyso0Nh2yyrNA==}
+    peerDependencies:
+      astro: ^6.0.0
+      wrangler: ^4.61.1
 
   '@astrojs/compiler-binding-darwin-arm64@0.1.6':
     resolution: {integrity: sha512-pYCFf5a/Tat+uRJU7xUSK0aw45kxnwAaKyhpnosJFCFhiiG4d/b7U526gaIqdcIZx6PbZ0hPOYDAxUYYfMDFaw==}
@@ -211,6 +220,9 @@ packages:
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/underscore-redirects@1.0.2':
+    resolution: {integrity: sha512-S3gTcWr3DVk2zvY7hEoEYjqpDe9fs0EL077EYIvvE7hEoPEaCOWRK+qzzm02Qm0T06vqzqHHDa3BD0/nhWXjvg==}
 
   '@astrojs/yaml2ts@0.2.3':
     resolution: {integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==}
@@ -378,8 +390,8 @@ packages:
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
     engines: {node: '>=18.0.0'}
 
-  '@cloudflare/unenv-preset@2.15.0':
-    resolution: {integrity: sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==}
+  '@cloudflare/unenv-preset@2.16.0':
+    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
     peerDependencies:
       unenv: 2.0.0-rc.24
       workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
@@ -387,32 +399,38 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260310.1':
-    resolution: {integrity: sha512-hF2VpoWaMb1fiGCQJqCY6M8I+2QQqjkyY4LiDYdTL5D/w6C1l5v1zhc0/jrjdD1DXfpJtpcSMSmEPjHse4p9Ig==}
+  '@cloudflare/vite-plugin@1.30.0':
+    resolution: {integrity: sha512-7E521lowup0TL6J7ete0TrjW/UJkS+NrwOZ9fXDkwPIUi+u1CaRqeoDihJtaJkoBMHF3qjvZpNf2424Hr6g95A==}
+    peerDependencies:
+      vite: ^6.1.0 || ^7.0.0 || ^8.0.0
+      wrangler: ^4.76.0
+
+  '@cloudflare/workerd-darwin-64@1.20260317.1':
+    resolution: {integrity: sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260310.1':
-    resolution: {integrity: sha512-h/Vl3XrYYPI6yFDE27XO1QPq/1G1lKIM8tzZGIWYpntK3IN5XtH3Ee/sLaegpJ49aIJoqhF2mVAZ6Yw+Vk2gJw==}
+  '@cloudflare/workerd-darwin-arm64@1.20260317.1':
+    resolution: {integrity: sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260310.1':
-    resolution: {integrity: sha512-XzQ0GZ8G5P4d74bQYOIP2Su4CLdNPpYidrInaSOuSxMw+HamsHaFrjVsrV2mPy/yk2hi6SY2yMbgKFK9YjA7vw==}
+  '@cloudflare/workerd-linux-64@1.20260317.1':
+    resolution: {integrity: sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260310.1':
-    resolution: {integrity: sha512-sxv4CxnN4ZR0uQGTFVGa0V4KTqwdej/czpIc5tYS86G8FQQoGIBiAIs2VvU7b8EROPcandxYHDBPTb+D9HIMPw==}
+  '@cloudflare/workerd-linux-arm64@1.20260317.1':
+    resolution: {integrity: sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260310.1':
-    resolution: {integrity: sha512-+1ZTViWKJypLfgH/luAHCqkent0DEBjAjvO40iAhOMHRLYP/SPphLvr4Jpi6lb+sIocS8Q1QZL4uM5Etg1Wskg==}
+  '@cloudflare/workerd-windows-64@1.20260317.1':
+    resolution: {integrity: sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -2223,8 +2241,8 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
-  miniflare@4.20260310.0:
-    resolution: {integrity: sha512-uC5vNPenFpDSj5aUU3wGSABG6UUqMr+Xs1m4AkCrTHo37F4Z6xcQw5BXqViTfPDVT/zcYH1UgTVoXhr1l6ZMXw==}
+  miniflare@4.20260317.1:
+    resolution: {integrity: sha512-A3csI1HXEIfqe3oscgpoRMHdYlkReQKPH/g5JE53vFSjoM6YIAOGAzyDNeYffwd9oQkPWDj9xER8+vpxei8klA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2698,12 +2716,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.18.2:
-    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.24.3:
-    resolution: {integrity: sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==}
+  undici@7.24.4:
+    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -3046,17 +3060,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  workerd@1.20260310.1:
-    resolution: {integrity: sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ==}
+  workerd@1.20260317.1:
+    resolution: {integrity: sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.72.0:
-    resolution: {integrity: sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg==}
+  wrangler@4.76.0:
+    resolution: {integrity: sha512-Wan+CU5a0tu4HIxGOrzjNbkmxCT27HUmzrMj6kc7aoAnjSLv50Ggcn2Ant7wNQrD6xW3g31phKupZJgTZ8wZfQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260310.1
+      '@cloudflare/workers-types': ^4.20260317.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -3181,6 +3195,32 @@ snapshots:
     transitivePeerDependencies:
       - prettier
       - prettier-plugin-astro
+
+  '@astrojs/cloudflare@13.1.3(@types/node@24.12.0)(astro@6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.30.2)(workerd@1.20260317.1)(wrangler@4.76.0)(yaml@2.8.2)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.8.0
+      '@astrojs/underscore-redirects': 1.0.2
+      '@cloudflare/vite-plugin': 1.30.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(workerd@1.20260317.1)(wrangler@4.76.0)
+      astro: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)
+      piccolore: 0.1.3
+      tinyglobby: 0.2.15
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      wrangler: 4.76.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - utf-8-validate
+      - workerd
+      - yaml
 
   '@astrojs/compiler-binding-darwin-arm64@0.1.6':
     optional: true
@@ -3385,6 +3425,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@astrojs/underscore-redirects@1.0.2': {}
+
   '@astrojs/yaml2ts@0.2.3':
     dependencies:
       yaml: 2.8.2
@@ -3561,25 +3603,38 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
-  '@cloudflare/unenv-preset@2.15.0(unenv@2.0.0-rc.24)(workerd@1.20260310.1)':
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260310.1
+      workerd: 1.20260317.1
 
-  '@cloudflare/workerd-darwin-64@1.20260310.1':
+  '@cloudflare/vite-plugin@1.30.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(workerd@1.20260317.1)(wrangler@4.76.0)':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
+      miniflare: 4.20260317.1
+      unenv: 2.0.0-rc.24
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      wrangler: 4.76.0
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - workerd
+
+  '@cloudflare/workerd-darwin-64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260310.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260310.1':
+  '@cloudflare/workerd-linux-64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260310.1':
+  '@cloudflare/workerd-linux-arm64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260310.1':
+  '@cloudflare/workerd-windows-64@1.20260317.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -5171,7 +5226,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.3
+      undici: 7.24.4
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5733,12 +5788,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  miniflare@4.20260310.0:
+  miniflare@4.20260317.1:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.18.2
-      workerd: 1.20260310.1
+      undici: 7.24.4
+      workerd: 1.20260317.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -6324,10 +6379,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.18.2: {}
-
-  undici@7.24.3:
-    optional: true
+  undici@7.24.4: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -6620,24 +6672,24 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  workerd@1.20260310.1:
+  workerd@1.20260317.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260310.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260310.1
-      '@cloudflare/workerd-linux-64': 1.20260310.1
-      '@cloudflare/workerd-linux-arm64': 1.20260310.1
-      '@cloudflare/workerd-windows-64': 1.20260310.1
+      '@cloudflare/workerd-darwin-64': 1.20260317.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260317.1
+      '@cloudflare/workerd-linux-64': 1.20260317.1
+      '@cloudflare/workerd-linux-arm64': 1.20260317.1
+      '@cloudflare/workerd-windows-64': 1.20260317.1
 
-  wrangler@4.72.0:
+  wrangler@4.76.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.15.0(unenv@2.0.0-rc.24)(workerd@1.20260310.1)
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260310.0
+      miniflare: 4.20260317.1
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260310.1
+      workerd: 1.20260317.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,12 @@ importers:
       astro:
         specifier: 6.0.8
         version: 6.0.8(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      better-auth:
+        specifier: 1.5.6
+        version: 1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(kysely@0.28.14))(solid-js@1.9.11)(vitest@4.1.0)
       drizzle-orm:
         specifier: 0.45.1
-        version: 0.45.1
+        version: 0.45.1(@opentelemetry/api@1.9.0)(kysely@0.28.14)
       sharp:
         specifier: 0.34.5
         version: 0.34.5
@@ -71,7 +74,7 @@ importers:
         version: 2.11.11(solid-js@1.9.11)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       wrangler:
         specifier: 4.76.0
         version: 4.76.0
@@ -317,6 +320,81 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@better-auth/core@1.5.6':
+    resolution: {integrity: sha512-Ez9DZdIMFyxHremmoLz1emFPGNQomDC1jqqBPnZ6Ci+6TiGN3R9w/Y03cJn6I8r1ycKgOzeVMZtJ/erOZ27Gsw==}
+    peerDependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.2
+      jose: ^6.1.0
+      kysely: ^0.28.5
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.5.6':
+    resolution: {integrity: sha512-VfFFmaoFw3ug12SiSuIwzrMoHyIVmkMGWm9gZ4sXdYYVX4HboCL4m3fjzOhppcmK5OGatRuU+N1UX6wxCITcXw==}
+    peerDependencies:
+      '@better-auth/core': 1.5.6
+      '@better-auth/utils': ^0.3.0
+      drizzle-orm: '>=0.41.0'
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.5.6':
+    resolution: {integrity: sha512-Fnf+h8WVKtw6lEOmVmiVVzDf3shJtM60AYf9XTnbdCeUd6MxN/KnaJZpkgtYnRs7a+nwtkVB+fg4lGETebGFXQ==}
+    peerDependencies:
+      '@better-auth/core': 1.5.6
+      '@better-auth/utils': ^0.3.0
+      kysely: ^0.27.0 || ^0.28.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.5.6':
+    resolution: {integrity: sha512-rS7ZsrIl5uvloUgNN0u9LOZJMMXnsZXVdUZ3MrTBKWM2KpoJjzPr9yN3Szyma5+0V7SltnzSGHPkYj2bEzzmlA==}
+    peerDependencies:
+      '@better-auth/core': 1.5.6
+      '@better-auth/utils': ^0.3.0
+
+  '@better-auth/mongo-adapter@1.5.6':
+    resolution: {integrity: sha512-6+M3MS2mor8fTUV3EI1FBLP0cs6QfbN+Ovx9+XxR/GdfKIBoNFzmPEPRbdGt+ft6PvrITsUm+T70+kkHgVSP6w==}
+    peerDependencies:
+      '@better-auth/core': 1.5.6
+      '@better-auth/utils': ^0.3.0
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.5.6':
+    resolution: {integrity: sha512-UxY9vQJs1Tt+O+T2YQnseDMlWmUSQvFZSBb5YiFRg7zcm+TEzujh4iX2/csA0YiZptLheovIuVWTP9nriewEBA==}
+    peerDependencies:
+      '@better-auth/core': 1.5.6
+      '@better-auth/utils': ^0.3.0
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.5.6':
+    resolution: {integrity: sha512-yXC7NSxnIFlxDkGdpD7KA+J9nqIQAPCJKe77GoaC5bWoe/DALo1MYorZfTgOafS7wrslNtsPT4feV/LJi1ubqQ==}
+    peerDependencies:
+      '@better-auth/core': 1.5.6
+
+  '@better-auth/utils@0.3.1':
+    resolution: {integrity: sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==}
+
+  '@better-fetch/fetch@1.1.21':
+    resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
   '@biomejs/biome@2.3.15':
     resolution: {integrity: sha512-u+jlPBAU2B45LDkjjNNYpc1PvqrM/co4loNommS9/sl9oSxsAQKsNZejYuUztvToB5oXi1tN/e62iNd6ESiY3g==}
@@ -1169,6 +1247,22 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@noble/ciphers@2.1.1':
+    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -1771,6 +1865,76 @@ packages:
   bcp-47@2.1.0:
     resolution: {integrity: sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==}
 
+  better-auth@1.5.6:
+    resolution: {integrity: sha512-QSpJTqaT1XVfWRQe/fm3PgeuwOIlz1nWX/Dx7nsHStJ382bLzmDbQk2u7IT0IJ6wS5SRxfqEE1Ev9TXontgyAQ==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: '>=0.41.0'
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.3.2:
+    resolution: {integrity: sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -2342,6 +2506,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2384,6 +2551,10 @@ packages:
   klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
+
+  kysely@0.28.14:
+    resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
+    engines: {node: '>=20.0.0'}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -2678,6 +2849,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanostores@1.2.0:
+    resolution: {integrity: sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
@@ -2932,6 +3107,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rou3@0.7.12:
+    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
   sax@1.4.4:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
@@ -2958,6 +3136,9 @@ packages:
   seroval@1.5.1:
     resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
     engines: {node: '>=10'}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -3976,6 +4157,58 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.2(zod@4.3.6)
+      jose: 6.2.2
+      kysely: 0.28.14
+      nanostores: 1.2.0
+      zod: 4.3.6
+
+  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(kysely@0.28.14))':
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/utils': 0.3.1
+    optionalDependencies:
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(kysely@0.28.14)
+
+  '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)':
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/utils': 0.3.1
+    optionalDependencies:
+      kysely: 0.28.14
+
+  '@better-auth/memory-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/utils': 0.3.1
+
+  '@better-auth/mongo-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/utils': 0.3.1
+
+  '@better-auth/prisma-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/utils': 0.3.1
+
+  '@better-auth/telemetry@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))':
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+
+  '@better-auth/utils@0.3.1': {}
+
+  '@better-fetch/fetch@1.1.21': {}
+
   '@biomejs/biome@2.3.15':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.3.15
@@ -4378,7 +4611,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@exodus/bytes@1.15.0':
+  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
     optional: true
 
   '@expressive-code/core@0.41.6':
@@ -4562,6 +4797,14 @@ snapshots:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@noble/ciphers@2.1.1': {}
+
+  '@noble/hashes@2.0.1': {}
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -4930,7 +5173,7 @@ snapshots:
       '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -4946,7 +5189,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -5220,6 +5463,43 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
+  better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(kysely@0.28.14))(solid-js@1.9.11)(vitest@4.1.0):
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(kysely@0.28.14))
+      '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)
+      '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.3.2(zod@4.3.6)
+      defu: 6.1.4
+      jose: 6.2.2
+      kysely: 0.28.14
+      nanostores: 1.2.0
+      zod: 4.3.6
+    optionalDependencies:
+      drizzle-kit: 0.31.10
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(kysely@0.28.14)
+      solid-js: 1.9.11
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-call@1.3.2(zod@4.3.6):
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 4.3.6
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -5325,10 +5605,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.0.1):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
@@ -5391,7 +5671,10 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.1: {}
+  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(kysely@0.28.14):
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      kysely: 0.28.14
 
   dset@3.1.4: {}
 
@@ -5803,9 +6086,9 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
@@ -5860,23 +6143,25 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.2: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.0.0:
+  jsdom@29.0.0(@noble/hashes@2.0.1):
     dependencies:
       '@asamuzakjp/css-color': 5.0.1
       '@asamuzakjp/dom-selector': 7.0.3
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.0.1)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.2.7
       parse5: 8.0.0
@@ -5887,7 +6172,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -5906,6 +6191,8 @@ snapshots:
   kleur@4.1.5: {}
 
   klona@2.0.6: {}
+
+  kysely@0.28.14: {}
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -6465,6 +6752,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanostores@1.2.0: {}
+
   neotraverse@0.6.18: {}
 
   nlcst-to-string@4.0.0:
@@ -6818,6 +7107,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  rou3@0.7.12: {}
+
   sax@1.4.4: {}
 
   saxes@6.0.0:
@@ -6834,6 +7125,8 @@ snapshots:
       seroval: 1.5.1
 
   seroval@1.5.1: {}
+
+  set-cookie-parser@3.1.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -7191,7 +7484,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.0(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(@vitest/browser-playwright@4.1.0)(jsdom@29.0.0(@noble/hashes@2.0.1))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
@@ -7214,9 +7507,10 @@ snapshots:
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 24.12.0
       '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
-      jsdom: 29.0.0
+      jsdom: 29.0.0(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - msw
 
@@ -7330,9 +7624,9 @@ snapshots:
   whatwg-mimetype@5.0.0:
     optional: true
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.0.1):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,10 +1,35 @@
 {
   "version": 1,
   "skills": {
+    "better-auth-best-practices": {
+      "source": "better-auth/skills",
+      "sourceType": "github",
+      "computedHash": "a4c830509e85557b59339d8d93a4e243e9e59c686e7678854d39230e12c2a6dc"
+    },
+    "create-auth-skill": {
+      "source": "better-auth/skills",
+      "sourceType": "github",
+      "computedHash": "31c027d02dbf1faa37f58191f574b9443143042fb2b684fe32df53ab0270487c"
+    },
+    "drizzle-orm": {
+      "source": "bobmatnyc/claude-mpm-skills",
+      "sourceType": "github",
+      "computedHash": "9aea7469d696c9b5fa54a84b7a92ea692872fb624fb028f866ab0f3deac84867"
+    },
+    "solidjs": {
+      "source": "suryavirkapur/skills",
+      "sourceType": "github",
+      "computedHash": "6195dd1cb5df073c6c835e3db3f6828541bcee6753a3c996473d934b80f1ebfa"
+    },
     "tdd": {
       "source": "mattpocock/skills",
       "sourceType": "github",
       "computedHash": "ad055544599481182d0079c4198e85da26677cb408a677be2da04915375f0427"
+    },
+    "workers-best-practices": {
+      "source": "cloudflare/skills",
+      "sourceType": "github",
+      "computedHash": "420e1ad3eaeb8ed2016e6b34fff3757de6aa39899ec2bd6e9784a29c38e70f9a"
     },
     "wrangler": {
       "source": "cloudflare/skills",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,89 @@
+---
+import config from 'virtual:starlight/user-config'
+
+import LanguageSelect from 'virtual:starlight/components/LanguageSelect'
+import Search from 'virtual:starlight/components/Search'
+import SiteTitle from 'virtual:starlight/components/SiteTitle'
+import SocialIcons from 'virtual:starlight/components/SocialIcons'
+import ThemeSelect from 'virtual:starlight/components/ThemeSelect'
+import UserMenu from '@/components/user-menu/UserMenu'
+
+const shouldRenderSearch =
+	config.pagefind ||
+	config.components.Search !== '@astrojs/starlight/components/Search.astro'
+---
+
+<div class="header">
+	<div class="title-wrapper sl-flex">
+		<SiteTitle />
+	</div>
+	<div class="sl-flex print:hidden">
+		{shouldRenderSearch && <Search />}
+	</div>
+	<div class="sl-hidden md:sl-flex print:hidden right-group">
+		<UserMenu client:only="solid-js" />
+		<div class="sl-flex social-icons">
+			<SocialIcons />
+		</div>
+		<ThemeSelect />
+		<LanguageSelect />
+	</div>
+</div>
+
+<style>
+	@layer starlight.core {
+		.header {
+			display: flex;
+			gap: var(--sl-nav-gap);
+			justify-content: space-between;
+			align-items: center;
+			height: 100%;
+		}
+
+		.title-wrapper {
+			overflow: clip;
+			padding: 0.25rem;
+			margin: -0.25rem;
+			min-width: 0;
+		}
+
+		.right-group,
+		.social-icons {
+			gap: 1rem;
+			align-items: center;
+		}
+		.social-icons::after {
+			content: '';
+			height: 2rem;
+			border-inline-end: 1px solid var(--sl-color-gray-5);
+		}
+
+		@media (min-width: 50rem) {
+			:global(:root[data-has-sidebar]) {
+				--__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+			}
+			:global(:root:not([data-has-toc])) {
+				--__toc-width: 0rem;
+			}
+			.header {
+				--__sidebar-width: max(0rem, var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x));
+				--__main-column-fr: calc(
+					(
+							100% + var(--__sidebar-pad, 0rem) - var(--__toc-width, var(--sl-sidebar-width)) -
+								(2 * var(--__toc-width, var(--sl-nav-pad-x))) - var(--sl-content-inline-start, 0rem) -
+								var(--sl-content-width)
+						) / 2
+				);
+				display: grid;
+				grid-template-columns:
+					minmax(
+						calc(var(--__sidebar-width) + max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))),
+						auto
+					)
+					1fr
+					auto;
+				align-content: center;
+			}
+		}
+	}
+</style>

--- a/src/components/TopicCards.astro
+++ b/src/components/TopicCards.astro
@@ -25,4 +25,4 @@ const { topics, subject } = Astro.props
 	</CardGrid>
 </noscript>
 
-<SubjectOverview client:load topics={topics} subject={subject} />
+<SubjectOverview client:only="solid-js" topics={topics} subject={subject} />

--- a/src/components/card-view/CardView.module.css
+++ b/src/components/card-view/CardView.module.css
@@ -76,3 +76,11 @@
 	block-size: 1.333em;
 	color: var(--sl-color-gray-3);
 }
+
+.checkmark {
+	position: absolute;
+	inset-block-end: 0.5rem;
+	inset-inline-end: 0.5rem;
+	block-size: 1.333em;
+	color: var(--sl-color-text-accent);
+}

--- a/src/components/card-view/CardView.tsx
+++ b/src/components/card-view/CardView.tsx
@@ -1,6 +1,7 @@
 import { For, Show } from 'solid-js'
 import type { Grade } from '@/components/grade-filter/grade'
 import { topicHref } from '@/lib/href'
+import { isTopicCompleted } from '@/lib/progress'
 import type { Topic } from '@/lib/topics'
 import { topicLabel } from '@/lib/topics'
 import styles from './CardView.module.css'
@@ -27,6 +28,7 @@ function Card(props: CardProps) {
 
 interface CardWithLinkProps extends CardProps {
 	href: string
+	completed?: boolean
 }
 
 function CardWithLink(props: CardWithLinkProps) {
@@ -46,8 +48,19 @@ function CardWithLink(props: CardWithLinkProps) {
 				fill="currentColor"
 				class={styles.icon}
 			>
-				<path d="M17.92 11.62a1.001 1.001 0 0 0-.21-.33l-5-5a1.003 1.003 0 1 0-1.42 1.42l3.3 3.29H7a1 1 0 0 0 0 2h7.59l-3.3 3.29a1.002 1.002 0 0 0 .325 1.639 1 1 0 0 0 1.095-.219l5-5a1 1 0 0 0 .21-.33 1 1 0 0 0 0-.76Z"></path>
+				<path d="M17.92 11.62a1.001 1.001 0 0 0-.21-.33l-5-5a1.003 1.003 0 1 0-1.42 1.42l3.3 3.29H7a1 1 0 0 0 0 2h7.59l-3.3 3.29a1.002 1.002 0 0 0 .325 1.639 1 1 0 0 0 1.095-.219l5-5a1 1 0 0 0 .21-.33 1 1 0 0 0 0-.76Z" />
 			</svg>
+			<Show when={props.completed}>
+				<svg
+					role="img"
+					aria-label="Hotovo"
+					viewBox="0 0 24 24"
+					fill="currentColor"
+					class={styles.checkmark}
+				>
+					<path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+				</svg>
+			</Show>
 		</div>
 	)
 }
@@ -56,6 +69,7 @@ interface CardViewProps {
 	topics: Topic[]
 	subject: string
 	grade: Grade
+	progress?: Record<string, boolean>
 }
 
 export default function CardView(props: CardViewProps) {
@@ -66,11 +80,23 @@ export default function CardView(props: CardViewProps) {
 					const available = () =>
 						props.grade === 'all' || topic.grades.includes(Number(props.grade))
 
+					const completed = () =>
+						props.progress
+							? isTopicCompleted(
+									props.progress,
+									props.subject,
+									topic.slug,
+									props.grade === 'all' ? 'all' : `${props.grade}-rocnik`,
+									topic.grades,
+								)
+							: false
+
 					return (
 						<Show when={available()} fallback={<Card topic={topic} />}>
 							<CardWithLink
 								topic={topic}
 								href={topicHref(props.subject, topic.slug, props.grade)}
+								completed={completed()}
 							/>
 						</Show>
 					)

--- a/src/components/subject-overview/SubjectOverview.tsx
+++ b/src/components/subject-overview/SubjectOverview.tsx
@@ -61,8 +61,13 @@ function SubjectOverviewInner(props: SubjectOverviewProps) {
 	const onToggle = async (slug: string, completed: boolean) => {
 		try {
 			await mutation.mutateAsync({ slug, completed })
-		} catch {
-			setToastMessage('Nepodařilo se uložit změnu')
+		} catch (err: unknown) {
+			const status = (err as { status?: number })?.status
+			if (status === 401) {
+				setToastMessage('Přihlášení vypršelo, přihlaste se znovu')
+			} else {
+				setToastMessage('Nepodařilo se uložit změnu')
+			}
 		}
 	}
 

--- a/src/components/subject-overview/SubjectOverview.tsx
+++ b/src/components/subject-overview/SubjectOverview.tsx
@@ -1,3 +1,4 @@
+import { QueryClientProvider } from '@tanstack/solid-query'
 import { createSignal, Match, onMount, Switch } from 'solid-js'
 import CardView from '@/components/card-view/CardView'
 import GradeFilter from '@/components/grade-filter/GradeFilter'
@@ -8,6 +9,7 @@ import {
 	isGrade,
 } from '@/components/grade-filter/grade'
 import TableView from '@/components/table-view/TableView'
+import Toast from '@/components/toast/Toast'
 import ViewToggle from '@/components/view-toggle/ViewToggle'
 import type { View } from '@/components/view-toggle/view'
 import {
@@ -15,6 +17,12 @@ import {
 	isView,
 	VIEW_STORAGE_KEY,
 } from '@/components/view-toggle/view'
+import { authClient } from '@/lib/auth-client'
+import {
+	createProgressMutation,
+	createProgressQuery,
+} from '@/lib/progress-hooks'
+import { queryClient } from '@/lib/query-client'
 import type { Topic } from '@/lib/topics'
 import style from './SubjectOverview.module.css'
 
@@ -24,8 +32,22 @@ interface SubjectOverviewProps {
 }
 
 export default function SubjectOverview(props: SubjectOverviewProps) {
+	return (
+		<QueryClientProvider client={queryClient}>
+			<SubjectOverviewInner {...props} />
+		</QueryClientProvider>
+	)
+}
+
+function SubjectOverviewInner(props: SubjectOverviewProps) {
 	const [grade, setGrade] = createSignal<Grade>(DEFAULT_GRADE)
 	const [view, setView] = createSignal<View>(DEFAULT_VIEW)
+	const [toastMessage, setToastMessage] = createSignal<string | undefined>()
+
+	const session = authClient.useSession()
+	const progress = createProgressQuery(props.subject, session)
+	const mutation = createProgressMutation(props.subject)
+
 	const onGradeChange = (g: Grade) => {
 		setGrade(g)
 		localStorage.setItem(GRADE_STORAGE_KEY, g)
@@ -34,6 +56,14 @@ export default function SubjectOverview(props: SubjectOverviewProps) {
 	const onViewChange = (v: View) => {
 		setView(v)
 		localStorage.setItem(VIEW_STORAGE_KEY, v)
+	}
+
+	const onToggle = async (slug: string, completed: boolean) => {
+		try {
+			await mutation.mutateAsync({ slug, completed })
+		} catch {
+			setToastMessage('Nepodařilo se uložit změnu')
+		}
 	}
 
 	onMount(() => {
@@ -55,6 +85,7 @@ export default function SubjectOverview(props: SubjectOverviewProps) {
 						topics={props.topics}
 						subject={props.subject}
 						grade={grade()}
+						progress={session()?.data ? progress.data : undefined}
 					/>
 				</Match>
 				<Match when={view() === 'table'}>
@@ -62,9 +93,15 @@ export default function SubjectOverview(props: SubjectOverviewProps) {
 						topics={props.topics}
 						subject={props.subject}
 						grade={grade()}
+						progress={session()?.data ? progress.data : undefined}
+						onToggle={onToggle}
 					/>
 				</Match>
 			</Switch>
+			<Toast
+				message={toastMessage()}
+				onDismiss={() => setToastMessage(undefined)}
+			/>
 		</>
 	)
 }

--- a/src/components/subject-overview/SubjectOverview.tsx
+++ b/src/components/subject-overview/SubjectOverview.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from '@tanstack/solid-query'
-import { createSignal, Match, onMount, Switch } from 'solid-js'
+import { createSignal, Match, onCleanup, onMount, Switch } from 'solid-js'
 import CardView from '@/components/card-view/CardView'
 import GradeFilter from '@/components/grade-filter/GradeFilter'
 import type { Grade } from '@/components/grade-filter/grade'
@@ -76,6 +76,15 @@ function SubjectOverviewInner(props: SubjectOverviewProps) {
 		if (storedGrade && isGrade(storedGrade)) setGrade(storedGrade)
 		const storedView = localStorage.getItem(VIEW_STORAGE_KEY)
 		if (storedView && isView(storedView)) setView(storedView)
+
+		const onOffline = () => setToastMessage('Jste offline — změny se neuloží')
+		const onOnline = () => setToastMessage(undefined)
+		window.addEventListener('offline', onOffline)
+		window.addEventListener('online', onOnline)
+		onCleanup(() => {
+			window.removeEventListener('offline', onOffline)
+			window.removeEventListener('online', onOnline)
+		})
 	})
 
 	return (

--- a/src/components/table-view/TableView.module.css
+++ b/src/components/table-view/TableView.module.css
@@ -52,3 +52,10 @@
 		text-decoration: underline;
 	}
 }
+
+.colGrade input[type="checkbox"] {
+	cursor: pointer;
+	inline-size: 1.125rem;
+	block-size: 1.125rem;
+	accent-color: var(--sl-color-text-accent);
+}

--- a/src/components/table-view/TableView.tsx
+++ b/src/components/table-view/TableView.tsx
@@ -2,8 +2,9 @@ import { For } from 'solid-js'
 import type { Grade } from '@/components/grade-filter/grade'
 import { GRADE_LABELS } from '@/components/grade-filter/grade'
 import { topicHref } from '@/lib/href'
+import { progressSlug } from '@/lib/progress'
 import type { Topic } from '@/lib/topics'
-import { formatTopicNumber } from '@/lib/topics'
+import { formatTopicNumber, topicLabel } from '@/lib/topics'
 import styles from './TableView.module.css'
 
 const NUMERIC_GRADES = ['6', '7', '8', '9'] as const
@@ -12,6 +13,8 @@ interface TableViewProps {
 	topics: Topic[]
 	subject: string
 	grade: Grade
+	progress?: Record<string, boolean>
+	onToggle?: (slug: string, completed: boolean) => void
 }
 
 export default function TableView(props: TableViewProps) {
@@ -57,24 +60,49 @@ export default function TableView(props: TableViewProps) {
 									</a>
 								</td>
 								<For each={NUMERIC_GRADES}>
-									{(g) => (
-										<td
-											class={styles.colGrade}
-											data-grade={g}
-											data-muted={isMuted(g) || undefined}
-										>
-											{topic.grades.includes(Number(g)) ? (
-												<a
-													href={topicHref(props.subject, topic.slug, g)}
-													aria-label={`${topic.title} — ${GRADE_LABELS[g]}`}
-												>
-													✅
-												</a>
-											) : (
-												'—'
-											)}
-										</td>
-									)}
+									{(g) => {
+										const available = topic.grades.includes(Number(g))
+										const slug = progressSlug(
+											props.subject,
+											topic.slug,
+											`${g}-rocnik`,
+										)
+										const label = `${topicLabel(topic)}, ${GRADE_LABELS[g]}`
+
+										return (
+											<td
+												class={styles.colGrade}
+												data-grade={g}
+												data-muted={isMuted(g) || undefined}
+											>
+												{available ? (
+													<>
+														{props.progress !== undefined && (
+															<input
+																type="checkbox"
+																checked={props.progress[slug] === true}
+																aria-label={label}
+																onChange={() =>
+																	props.onToggle?.(
+																		slug,
+																		props.progress?.[slug] !== true,
+																	)
+																}
+															/>
+														)}
+														<a
+															href={topicHref(props.subject, topic.slug, g)}
+															aria-label={`${topic.title} — ${GRADE_LABELS[g]}`}
+														>
+															✅
+														</a>
+													</>
+												) : (
+													'—'
+												)}
+											</td>
+										)
+									}}
 								</For>
 							</tr>
 						)}

--- a/src/components/toast/Toast.module.css
+++ b/src/components/toast/Toast.module.css
@@ -1,0 +1,26 @@
+.toast {
+	position: fixed;
+	inset-block-end: 1rem;
+	inset-inline-end: 1rem;
+	z-index: 100;
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.75rem 1rem;
+	border-radius: 0.5rem;
+	border: 1px solid var(--sl-color-red);
+	background: var(--sl-color-red-low);
+	color: var(--sl-color-white);
+	box-shadow: var(--sl-shadow-md);
+}
+
+.close {
+	all: unset;
+	cursor: pointer;
+	color: var(--sl-color-white);
+	opacity: 0.7;
+
+	&:hover {
+		opacity: 1;
+	}
+}

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,0 +1,33 @@
+import { createEffect, onCleanup, Show } from 'solid-js'
+import styles from './Toast.module.css'
+
+interface ToastProps {
+	message: string | undefined
+	onDismiss?: () => void
+	duration?: number
+}
+
+export default function Toast(props: ToastProps) {
+	createEffect(() => {
+		if (!props.message) return
+
+		const timer = setTimeout(() => props.onDismiss?.(), props.duration ?? 5000)
+		onCleanup(() => clearTimeout(timer))
+	})
+
+	return (
+		<Show when={props.message}>
+			<div class={styles.toast} role="alert" aria-live="polite">
+				<span>{props.message}</span>
+				<button
+					type="button"
+					class={styles.close}
+					aria-label="Zavřít"
+					onClick={() => props.onDismiss?.()}
+				>
+					✕
+				</button>
+			</div>
+		</Show>
+	)
+}

--- a/src/components/user-menu/UserMenu.module.css
+++ b/src/components/user-menu/UserMenu.module.css
@@ -1,0 +1,23 @@
+.menu {
+	display: inline flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.signIn,
+.signOut {
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.35rem;
+	cursor: pointer;
+	padding: 0.25rem 0.75rem;
+
+	&:hover {
+		background-color: var(--sl-color-gray-7, var(--sl-color-gray-6));
+		border-color: var(--sl-color-gray-2);
+	}
+}
+
+.name {
+	font-size: var(--sl-text-sm);
+	color: var(--sl-color-white);
+}

--- a/src/components/user-menu/UserMenu.tsx
+++ b/src/components/user-menu/UserMenu.tsx
@@ -5,16 +5,16 @@ import style from './UserMenu.module.css'
 export default function UserMenu() {
 	const session = authClient.useSession()
 
+	const handleSignIn = () =>
+		authClient.signIn.social({ provider: 'google' }).catch(() => {})
+	const handleSignOut = () => authClient.signOut().catch(() => {})
+
 	return (
 		<div class={style.menu}>
 			<Show
 				when={session().data?.user}
 				fallback={
-					<button
-						type="button"
-						class={style.signIn}
-						onClick={() => authClient.signIn.social({ provider: 'google' })}
-					>
+					<button type="button" class={style.signIn} onClick={handleSignIn}>
 						Přihlásit se
 					</button>
 				}
@@ -22,11 +22,7 @@ export default function UserMenu() {
 				{(user) => (
 					<>
 						<span class={style.name}>{user().name}</span>
-						<button
-							type="button"
-							class={style.signOut}
-							onClick={() => authClient.signOut()}
-						>
+						<button type="button" class={style.signOut} onClick={handleSignOut}>
 							Odhlásit
 						</button>
 					</>

--- a/src/components/user-menu/UserMenu.tsx
+++ b/src/components/user-menu/UserMenu.tsx
@@ -1,0 +1,37 @@
+import { Show } from 'solid-js'
+import { authClient } from '@/lib/auth-client'
+import style from './UserMenu.module.css'
+
+export default function UserMenu() {
+	const session = authClient.useSession()
+
+	return (
+		<div class={style.menu}>
+			<Show
+				when={session().data?.user}
+				fallback={
+					<button
+						type="button"
+						class={style.signIn}
+						onClick={() => authClient.signIn.social({ provider: 'google' })}
+					>
+						Přihlásit se
+					</button>
+				}
+			>
+				{(user) => (
+					<>
+						<span class={style.name}>{user().name}</span>
+						<button
+							type="button"
+							class={style.signOut}
+							onClick={() => authClient.signOut()}
+						>
+							Odhlásit
+						</button>
+					</>
+				)}
+			</Show>
+		</div>
+	)
+}

--- a/src/components/user-menu/UserMenu.tsx
+++ b/src/components/user-menu/UserMenu.tsx
@@ -1,9 +1,10 @@
-import { Show } from 'solid-js'
+import { Match, Switch } from 'solid-js'
 import { authClient } from '@/lib/auth-client'
 import style from './UserMenu.module.css'
 
 export default function UserMenu() {
 	const session = authClient.useSession()
+	const authAvailable = () => session().isPending || !session().error
 
 	const handleSignIn = () =>
 		authClient.signIn.social({ provider: 'google' }).catch(() => {})
@@ -11,23 +12,27 @@ export default function UserMenu() {
 
 	return (
 		<div class={style.menu}>
-			<Show
-				when={session().data?.user}
-				fallback={
+			<Switch>
+				<Match when={session().data?.user}>
+					{(user) => (
+						<>
+							<span class={style.name}>{user().name}</span>
+							<button
+								type="button"
+								class={style.signOut}
+								onClick={handleSignOut}
+							>
+								Odhlásit
+							</button>
+						</>
+					)}
+				</Match>
+				<Match when={authAvailable()}>
 					<button type="button" class={style.signIn} onClick={handleSignIn}>
 						Přihlásit se
 					</button>
-				}
-			>
-				{(user) => (
-					<>
-						<span class={style.name}>{user().name}</span>
-						<button type="button" class={style.signOut} onClick={handleSignOut}>
-							Odhlásit
-						</button>
-					</>
-				)}
-			</Show>
+				</Match>
+			</Switch>
 		</div>
 	)
 }

--- a/src/db/auth-schema.ts
+++ b/src/db/auth-schema.ts
@@ -1,0 +1,57 @@
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const user = sqliteTable('user', {
+	id: text('id').primaryKey(),
+	name: text('name').notNull(),
+	email: text('email').notNull().unique(),
+	emailVerified: integer('email_verified', { mode: 'boolean' })
+		.notNull()
+		.default(false),
+	image: text('image'),
+	createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+	updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+})
+
+export const session = sqliteTable('session', {
+	id: text('id').primaryKey(),
+	expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+	token: text('token').notNull().unique(),
+	createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+	updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+	ipAddress: text('ip_address'),
+	userAgent: text('user_agent'),
+	userId: text('user_id')
+		.notNull()
+		.references(() => user.id),
+})
+
+export const account = sqliteTable('account', {
+	id: text('id').primaryKey(),
+	accountId: text('account_id').notNull(),
+	providerId: text('provider_id').notNull(),
+	userId: text('user_id')
+		.notNull()
+		.references(() => user.id),
+	accessToken: text('access_token'),
+	refreshToken: text('refresh_token'),
+	idToken: text('id_token'),
+	accessTokenExpiresAt: integer('access_token_expires_at', {
+		mode: 'timestamp',
+	}),
+	refreshTokenExpiresAt: integer('refresh_token_expires_at', {
+		mode: 'timestamp',
+	}),
+	scope: text('scope'),
+	password: text('password'),
+	createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+	updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+})
+
+export const verification = sqliteTable('verification', {
+	id: text('id').primaryKey(),
+	identifier: text('identifier').notNull(),
+	value: text('value').notNull(),
+	expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+	createdAt: integer('created_at', { mode: 'timestamp' }),
+	updatedAt: integer('updated_at', { mode: 'timestamp' }),
+})

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,7 @@
+import type { AnyD1Database } from 'drizzle-orm/d1'
+import { drizzle } from 'drizzle-orm/d1'
+import * as schema from './schema'
+
+export function createDb(d1: AnyD1Database) {
+	return drizzle(d1, { schema })
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,7 +1,8 @@
 import type { AnyD1Database } from 'drizzle-orm/d1'
 import { drizzle } from 'drizzle-orm/d1'
+import * as authSchema from './auth-schema'
 import * as schema from './schema'
 
 export function createDb(d1: AnyD1Database) {
-	return drizzle(d1, { schema })
+	return drizzle(d1, { schema: { ...schema, ...authSchema } })
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,24 @@
+import {
+	integer,
+	sqliteTable,
+	text,
+	uniqueIndex,
+} from 'drizzle-orm/sqlite-core'
+
+export const userProgress = sqliteTable(
+	'user_progress',
+	{
+		id: text('id')
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		userId: text('user_id').notNull(),
+		slug: text('slug').notNull(),
+		completed: integer('completed', { mode: 'boolean' })
+			.notNull()
+			.default(false),
+		updatedAt: integer('updated_at', { mode: 'timestamp' })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(table) => [uniqueIndex('idx_user_slug').on(table.userId, table.slug)],
+)

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,16 @@
 /// <reference path="../node_modules/@astrojs/starlight/virtual.d.ts" />
 /// <reference path="../node_modules/@astrojs/starlight/virtual-internal.d.ts" />
+
+declare module 'cloudflare:workers' {
+	const env: {
+		DB: import('drizzle-orm/d1').AnyD1Database
+	}
+	export { env }
+}
+
+declare namespace App {
+	interface Locals {
+		db: ReturnType<typeof import('./db').createDb>
+		auth: ReturnType<typeof import('./lib/auth').createAuth>
+	}
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,0 +1,3 @@
+import { createAuthClient } from 'better-auth/solid'
+
+export const authClient = createAuthClient()

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,8 @@
-import { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET } from 'astro:env/server'
+import {
+	BETTER_AUTH_URL,
+	GOOGLE_CLIENT_ID,
+	GOOGLE_CLIENT_SECRET,
+} from 'astro:env/server'
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import type { createDb } from '@/db'
@@ -18,6 +22,7 @@ export function createAuth(db: ReturnType<typeof createDb>) {
 	}
 
 	return betterAuth({
+		baseURL: BETTER_AUTH_URL,
 		database: drizzleAdapter(db, { provider: 'sqlite' }),
 		socialProviders: {
 			google: {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,15 +10,19 @@ import type { createDb } from '@/db'
  * at runtime via the Cloudflare Workers environment.
  *
  * @param db - Drizzle D1 database instance from `createDb()`
- * @returns Better Auth instance with `.handler()` and `.api` methods
+ * @returns Better Auth instance, or `undefined` when OAuth credentials are missing
  */
 export function createAuth(db: ReturnType<typeof createDb>) {
+	if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET) {
+		return undefined
+	}
+
 	return betterAuth({
 		database: drizzleAdapter(db, { provider: 'sqlite' }),
 		socialProviders: {
 			google: {
-				clientId: GOOGLE_CLIENT_ID ?? '',
-				clientSecret: GOOGLE_CLIENT_SECRET ?? '',
+				clientId: GOOGLE_CLIENT_ID,
+				clientSecret: GOOGLE_CLIENT_SECRET,
 			},
 		},
 	})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,15 @@ import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import type { createDb } from '@/db'
 
+/**
+ * Create a Better Auth instance with Drizzle adapter and Google OAuth.
+ *
+ * Called per-request from middleware — D1 binding is only available
+ * at runtime via the Cloudflare Workers environment.
+ *
+ * @param db - Drizzle D1 database instance from `createDb()`
+ * @returns Better Auth instance with `.handler()` and `.api` methods
+ */
 export function createAuth(db: ReturnType<typeof createDb>) {
 	return betterAuth({
 		database: drizzleAdapter(db, { provider: 'sqlite' }),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,16 @@
+import { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET } from 'astro:env/server'
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import type { createDb } from '@/db'
+
+export function createAuth(db: ReturnType<typeof createDb>) {
+	return betterAuth({
+		database: drizzleAdapter(db, { provider: 'sqlite' }),
+		socialProviders: {
+			google: {
+				clientId: GOOGLE_CLIENT_ID ?? '',
+				clientSecret: GOOGLE_CLIENT_SECRET ?? '',
+			},
+		},
+	})
+}

--- a/src/lib/progress-hooks.ts
+++ b/src/lib/progress-hooks.ts
@@ -1,0 +1,77 @@
+import type { CreateQueryResult } from '@tanstack/solid-query'
+import {
+	createMutation,
+	createQuery,
+	useQueryClient,
+} from '@tanstack/solid-query'
+import type { Accessor } from 'solid-js'
+
+type ProgressMap = Record<string, boolean>
+
+/**
+ * TanStack Query wrapper for fetching progress data.
+ *
+ * Fetches `GET /api/progress?subject={subject}` and returns a
+ * `{ [slug]: boolean }` map. Only enabled when the user is authenticated.
+ *
+ * @param subject - Subject slug, e.g. `"matematika"`
+ * @param session - Reactive session accessor from `authClient.useSession()`
+ * @returns TanStack `CreateQueryResult` with progress map
+ */
+export function createProgressQuery(
+	subject: string,
+	session: Accessor<{ data: unknown } | undefined>,
+): CreateQueryResult<ProgressMap> {
+	return createQuery(() => ({
+		queryKey: ['progress', subject],
+		queryFn: () =>
+			fetch(`/api/progress?subject=${subject}`).then((r) => r.json()),
+		enabled: !!session()?.data,
+	}))
+}
+
+/**
+ * TanStack Mutation wrapper for toggling progress.
+ *
+ * POSTs to `/api/progress` with `{ slug, completed }`.
+ * Applies optimistic update to the query cache immediately,
+ * reverts on error, and refetches on settle.
+ *
+ * @param subject - Subject slug for cache key scoping
+ * @returns TanStack `CreateMutationResult`
+ */
+export function createProgressMutation(subject: string) {
+	const queryClient = useQueryClient()
+
+	return createMutation(() => ({
+		mutationFn: (data: { slug: string; completed: boolean }) =>
+			fetch('/api/progress', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(data),
+			}).then((r) => r.json()),
+		onMutate: async (data) => {
+			await queryClient.cancelQueries({ queryKey: ['progress', subject] })
+
+			const previous = queryClient.getQueryData<ProgressMap>([
+				'progress',
+				subject,
+			])
+
+			queryClient.setQueryData<ProgressMap>(['progress', subject], (old) => ({
+				...old,
+				[data.slug]: data.completed,
+			}))
+
+			return { previous }
+		},
+		onError: (_err, _data, context) => {
+			if (context?.previous) {
+				queryClient.setQueryData(['progress', subject], context.previous)
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: ['progress', subject] })
+		},
+	}))
+}

--- a/src/lib/progress-hooks.ts
+++ b/src/lib/progress-hooks.ts
@@ -8,6 +8,25 @@ import type { Accessor } from 'solid-js'
 
 type ProgressMap = Record<string, boolean>
 
+export class ProgressError extends Error {
+	status: number
+	constructor(status: number, message: string) {
+		super(message)
+		this.status = status
+	}
+}
+
+export async function checkResponse(response: Response): Promise<unknown> {
+	if (!response.ok) {
+		throw new ProgressError(response.status, `HTTP ${response.status}`)
+	}
+	try {
+		return await response.json()
+	} catch {
+		throw new ProgressError(response.status, 'Invalid JSON response')
+	}
+}
+
 /**
  * TanStack Query wrapper for fetching progress data.
  *
@@ -25,7 +44,9 @@ export function createProgressQuery(
 	return createQuery(() => ({
 		queryKey: ['progress', subject],
 		queryFn: () =>
-			fetch(`/api/progress?subject=${subject}`).then((r) => r.json()),
+			fetch(`/api/progress?${new URLSearchParams({ subject })}`).then(
+				checkResponse,
+			) as Promise<ProgressMap>,
 		enabled: !!session()?.data,
 	}))
 }
@@ -49,7 +70,7 @@ export function createProgressMutation(subject: string) {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify(data),
-			}).then((r) => r.json()),
+			}).then(checkResponse),
 		onMutate: async (data) => {
 			await queryClient.cancelQueries({ queryKey: ['progress', subject] })
 
@@ -59,7 +80,7 @@ export function createProgressMutation(subject: string) {
 			])
 
 			queryClient.setQueryData<ProgressMap>(['progress', subject], (old) => ({
-				...old,
+				...(old ?? {}),
 				[data.slug]: data.completed,
 			}))
 

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -1,0 +1,45 @@
+import { and, eq, like } from 'drizzle-orm'
+import type { createDb } from '@/db'
+import { userProgress } from '@/db/schema'
+
+type Db = ReturnType<typeof createDb>
+
+export async function getProgress(
+	db: Db,
+	userId: string,
+	subject: string,
+	grade?: string,
+): Promise<Record<string, boolean>> {
+	const pattern = grade ? `${subject}/%/${grade}` : `${subject}/%`
+
+	const rows = await db
+		.select({ slug: userProgress.slug, completed: userProgress.completed })
+		.from(userProgress)
+		.where(
+			and(eq(userProgress.userId, userId), like(userProgress.slug, pattern)),
+		)
+
+	const result: Record<string, boolean> = {}
+	for (const row of rows) {
+		result[row.slug] = row.completed
+	}
+	return result
+}
+
+export async function toggleProgress(
+	db: Db,
+	userId: string,
+	slug: string,
+	completed: boolean,
+) {
+	const [row] = await db
+		.insert(userProgress)
+		.values({ userId, slug, completed })
+		.onConflictDoUpdate({
+			target: [userProgress.userId, userProgress.slug],
+			set: { completed, updatedAt: new Date() },
+		})
+		.returning()
+
+	return row
+}

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -2,6 +2,35 @@ import { and, eq, like } from 'drizzle-orm'
 import type { createDb } from '@/db'
 import { userProgress } from '@/db/schema'
 
+const SLUG_RE = /^[a-z0-9-]+(?:\/[a-z0-9-]+){1,2}\/[0-9]+-rocnik$/
+const SUBJECT_RE = /^[a-z0-9-]+(?:\/[a-z0-9-]+)?$/
+const GRADE_RE = /^[0-9]+-rocnik$/
+
+export function isProgressSlug(value: unknown): value is string {
+	return typeof value === 'string' && SLUG_RE.test(value)
+}
+
+export function isSubjectParam(value: unknown): value is string {
+	return typeof value === 'string' && value.length > 0 && SUBJECT_RE.test(value)
+}
+
+export function isGradeParam(value: unknown): value is string {
+	return typeof value === 'string' && GRADE_RE.test(value)
+}
+
+export function isProgressBody(
+	value: unknown,
+): value is { slug: string; completed: boolean } {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'slug' in value &&
+		'completed' in value &&
+		isProgressSlug((value as Record<string, unknown>).slug) &&
+		typeof (value as Record<string, unknown>).completed === 'boolean'
+	)
+}
+
 /**
  * Check if a topic is completed for the given grade.
  *

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -2,8 +2,78 @@ import { and, eq, like } from 'drizzle-orm'
 import type { createDb } from '@/db'
 import { userProgress } from '@/db/schema'
 
+/**
+ * Check if a topic is completed for the given grade.
+ *
+ * When grade is a specific value, checks that single slug.
+ * When grade is `"all"`, checks that every available grade is completed.
+ *
+ * @param progress - `{ [slug]: boolean }` map from the progress query
+ * @param subject - Subject slug, e.g. `"matematika"`
+ * @param topicSlug - Topic directory slug, e.g. `"01-pocetni-operace"`
+ * @param grade - Grade string (`"6-rocnik"`) or `"all"` for all grades
+ * @param availableGrades - Grade numbers available for the topic, e.g. `[6, 7, 8, 9]`
+ * @returns `true` if the topic-grade (or all grades) is completed
+ *
+ * @example
+ * isTopicCompleted(progress, 'matematika', '01', '6-rocnik', [6, 7, 8, 9])
+ *
+ * @example
+ * isTopicCompleted(progress, 'matematika', '01', 'all', [6, 7, 8, 9])
+ * // => true only if all 4 grades are completed
+ */
+export function isTopicCompleted(
+	progress: Record<string, boolean>,
+	subject: string,
+	topicSlug: string,
+	grade: string,
+	availableGrades: number[],
+): boolean {
+	if (grade === 'all') {
+		return availableGrades.every(
+			(g) => progress[progressSlug(subject, topicSlug, `${g}-rocnik`)] === true,
+		)
+	}
+	return progress[progressSlug(subject, topicSlug, grade)] === true
+}
+
+/**
+ * Build a progress slug from subject, topic directory, and grade.
+ *
+ * @param subject - Subject slug, e.g. `"matematika"`
+ * @param topicSlug - Topic directory slug, e.g. `"01-pocetni-operace"`
+ * @param grade - Grade string, e.g. `"6-rocnik"`
+ * @returns Progress slug, e.g. `"matematika/01-pocetni-operace/6-rocnik"`
+ *
+ * @example
+ * progressSlug('matematika', '01-pocetni-operace', '6-rocnik')
+ * // => 'matematika/01-pocetni-operace/6-rocnik'
+ */
+export function progressSlug(
+	subject: string,
+	topicSlug: string,
+	grade: string,
+): string {
+	return `${subject}/${topicSlug}/${grade}`
+}
+
 type Db = ReturnType<typeof createDb>
 
+/**
+ * Fetch all progress entries for a user within a subject.
+ *
+ * Server-side only — called from the progress API route.
+ *
+ * @param db - Drizzle D1 database instance
+ * @param userId - Authenticated user ID
+ * @param subject - Subject slug, e.g. `"matematika"`
+ * @param grade - Optional grade filter, e.g. `"7-rocnik"`
+ * @returns `{ [slug]: boolean }` map of completion state
+ *
+ * @example
+ * await getProgress(db, 'user-1', 'matematika')
+ * // => { 'matematika/01/6-rocnik': true, 'matematika/02/6-rocnik': false }
+ */
 export async function getProgress(
 	db: Db,
 	userId: string,
@@ -26,6 +96,18 @@ export async function getProgress(
 	return result
 }
 
+/**
+ * Insert or update a single progress entry.
+ *
+ * Uses upsert on the `(user_id, slug)` unique index.
+ * Server-side only — called from the progress API route.
+ *
+ * @param db - Drizzle D1 database instance
+ * @param userId - Authenticated user ID
+ * @param slug - Full progress slug, e.g. `"matematika/01/6-rocnik"`
+ * @param completed - Whether the topic-grade is completed
+ * @returns The upserted row
+ */
 export async function toggleProgress(
 	db: Db,
 	userId: string,

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/solid-query'
+
+export const queryClient = new QueryClient()

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -8,6 +8,20 @@ function isObject(entry: SidebarEntry): entry is SidebarObject {
 	return typeof entry !== 'string'
 }
 
+/**
+ * Find the parent sidebar group that contains an entry with the given slug.
+ *
+ * Searches recursively through nested sidebar items. Returns the group
+ * (has `items`) that directly contains a child matching the slug.
+ *
+ * @param items - Sidebar entries to search
+ * @param slug - Slug identifying the target entry
+ * @returns The parent group, or `undefined` if not found
+ *
+ * @example
+ * findGroupBySlug(sidebar, 'ja-a-svet/chemie')
+ * // => { label: 'Já a svět', items: [...] }
+ */
 export function findGroupBySlug(
 	items: SidebarEntry[],
 	slug: string,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,15 +2,22 @@ import { defineMiddleware } from 'astro:middleware'
 import { createDb } from '@/db'
 import { createAuth } from '@/lib/auth'
 
-export const onRequest = defineMiddleware(async (ctx, next) => {
+async function getD1() {
 	try {
-		const { env } = await import('cloudflare:workers')
-		if (env.DB) {
-			ctx.locals.db = createDb(env.DB)
-			ctx.locals.auth = createAuth(ctx.locals.db)
-		}
+		const mod = await (Function(
+			'return import("cloudflare:workers")',
+		)() as Promise<{ env: { DB?: unknown } }>)
+		return mod.env.DB
 	} catch {
-		// cloudflare:workers import fails during Node.js prerendering — expected.
+		// Not in workerd (Node.js prerender / local dev without wrangler).
+	}
+}
+
+export const onRequest = defineMiddleware(async (ctx, next) => {
+	const db = await getD1()
+	if (db) {
+		ctx.locals.db = createDb(db)
+		ctx.locals.auth = createAuth(ctx.locals.db)
 	}
 	return next()
 })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import { defineMiddleware } from 'astro:middleware'
+import { createDb } from '@/db'
+import { createAuth } from '@/lib/auth'
+
+export const onRequest = defineMiddleware(async (ctx, next) => {
+	try {
+		const { env } = await import('cloudflare:workers')
+		if (env.DB) {
+			ctx.locals.db = createDb(env.DB)
+			ctx.locals.auth = createAuth(ctx.locals.db)
+		}
+	} catch {
+		// cloudflare:workers unavailable during Node.js prerendering
+	}
+	return next()
+})

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,21 +2,50 @@ import { defineMiddleware } from 'astro:middleware'
 import { createDb } from '@/db'
 import { createAuth } from '@/lib/auth'
 
+let platformEnv: Record<string, unknown> | undefined
+
+/**
+ * Obtain the D1 database binding.
+ *
+ * Astro's Cloudflare adapter runs middleware in two different environments
+ * during dev: workerd (SSR via Miniflare) and Node.js (prerender + API routes).
+ * `cloudflare:workers` only provides real bindings in workerd. In Node.js it
+ * either throws or returns a stub with empty `env` (see prerender-stub in
+ * starlight-cloudflare-compat plugin). When the binding is missing we fall
+ * back to wrangler's `getPlatformProxy()` which gives us a local SQLite-backed
+ * D1 that works in Node.js.
+ *
+ * The `import.meta.env.DEV` guard ensures Rollup tree-shakes the wrangler
+ * import out of the production bundle (wrangler is a devDependency).
+ *
+ * In production everything runs in workerd, so `cloudflare:workers` works
+ * directly — no fallback needed.
+ *
+ * @see https://github.com/withastro/astro/issues/13523
+ */
 async function getD1() {
-	try {
-		const mod = await (Function(
-			'return import("cloudflare:workers")',
-		)() as Promise<{ env: { DB?: unknown } }>)
-		return mod.env.DB
-	} catch {
-		// Not in workerd (Node.js prerender / local dev without wrangler).
+	if (import.meta.env.DEV) {
+		try {
+			const { env } = await import('cloudflare:workers')
+			if ((env as { DB?: unknown }).DB) return (env as { DB?: unknown }).DB
+		} catch {
+			// Not in workerd and no stub — plain Node.js environment.
+		}
+		if (!platformEnv) {
+			const { getPlatformProxy } = await import('wrangler')
+			const proxy = await getPlatformProxy()
+			platformEnv = proxy.env as Record<string, unknown>
+		}
+		return platformEnv.DB
 	}
+	const { env } = await import('cloudflare:workers')
+	return (env as { DB?: unknown }).DB
 }
 
 export const onRequest = defineMiddleware(async (ctx, next) => {
-	const db = await getD1()
-	if (db) {
-		ctx.locals.db = createDb(db)
+	const d1 = await getD1()
+	if (d1) {
+		ctx.locals.db = createDb(d1)
 		ctx.locals.auth = createAuth(ctx.locals.db)
 	}
 	return next()

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,7 @@ export const onRequest = defineMiddleware(async (ctx, next) => {
 			ctx.locals.auth = createAuth(ctx.locals.db)
 		}
 	} catch {
-		// cloudflare:workers unavailable during Node.js prerendering
+		// cloudflare:workers import fails during Node.js prerendering — expected.
 	}
 	return next()
 })

--- a/src/pages/api/auth/[...all].ts
+++ b/src/pages/api/auth/[...all].ts
@@ -1,5 +1,8 @@
 import type { APIRoute } from 'astro'
 
 export const ALL: APIRoute = async (ctx) => {
+	if (!ctx.locals.auth) {
+		return new Response('Auth not available', { status: 503 })
+	}
 	return ctx.locals.auth.handler(ctx.request)
 }

--- a/src/pages/api/auth/[...all].ts
+++ b/src/pages/api/auth/[...all].ts
@@ -1,0 +1,5 @@
+import type { APIRoute } from 'astro'
+
+export const ALL: APIRoute = async (ctx) => {
+	return ctx.locals.auth.handler(ctx.request)
+}

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,5 @@
+import type { APIRoute } from 'astro'
+
+export const GET: APIRoute = () => {
+	return Response.json({ ok: true })
+}

--- a/src/pages/api/progress.ts
+++ b/src/pages/api/progress.ts
@@ -1,0 +1,53 @@
+import type { APIRoute } from 'astro'
+import { getProgress, toggleProgress } from '@/lib/progress'
+
+export const GET: APIRoute = async (ctx) => {
+	if (!ctx.locals.auth) {
+		return new Response(null, { status: 401 })
+	}
+
+	const session = await ctx.locals.auth.api.getSession({
+		headers: ctx.request.headers,
+	})
+	if (!session) {
+		return new Response(null, { status: 401 })
+	}
+
+	const subject = ctx.url.searchParams.get('subject')
+	if (!subject) {
+		return new Response('Missing subject parameter', { status: 400 })
+	}
+
+	const grade = ctx.url.searchParams.get('grade') ?? undefined
+	const progress = await getProgress(
+		ctx.locals.db,
+		session.user.id,
+		subject,
+		grade,
+	)
+
+	return Response.json(progress)
+}
+
+export const POST: APIRoute = async (ctx) => {
+	if (!ctx.locals.auth) {
+		return new Response(null, { status: 401 })
+	}
+
+	const session = await ctx.locals.auth.api.getSession({
+		headers: ctx.request.headers,
+	})
+	if (!session) {
+		return new Response(null, { status: 401 })
+	}
+
+	const body = await ctx.request.json()
+	const row = await toggleProgress(
+		ctx.locals.db,
+		session.user.id,
+		body.slug,
+		body.completed,
+	)
+
+	return Response.json(row)
+}

--- a/src/pages/api/progress.ts
+++ b/src/pages/api/progress.ts
@@ -1,5 +1,11 @@
 import type { APIRoute } from 'astro'
-import { getProgress, toggleProgress } from '@/lib/progress'
+import {
+	getProgress,
+	isGradeParam,
+	isProgressBody,
+	isSubjectParam,
+	toggleProgress,
+} from '@/lib/progress'
 
 export const GET: APIRoute = async (ctx) => {
 	if (!ctx.locals.auth) {
@@ -17,16 +23,27 @@ export const GET: APIRoute = async (ctx) => {
 	if (!subject) {
 		return new Response('Missing subject parameter', { status: 400 })
 	}
+	if (!isSubjectParam(subject)) {
+		return new Response('Invalid subject', { status: 400 })
+	}
 
 	const grade = ctx.url.searchParams.get('grade') ?? undefined
-	const progress = await getProgress(
-		ctx.locals.db,
-		session.user.id,
-		subject,
-		grade,
-	)
+	if (grade !== undefined && !isGradeParam(grade)) {
+		return new Response('Invalid grade', { status: 400 })
+	}
 
-	return Response.json(progress)
+	try {
+		const progress = await getProgress(
+			ctx.locals.db,
+			session.user.id,
+			subject,
+			grade,
+		)
+		return Response.json(progress)
+	} catch (err) {
+		console.error('[progress]', err)
+		return new Response('Internal error', { status: 500 })
+	}
 }
 
 export const POST: APIRoute = async (ctx) => {
@@ -41,13 +58,27 @@ export const POST: APIRoute = async (ctx) => {
 		return new Response(null, { status: 401 })
 	}
 
-	const body = await ctx.request.json()
-	const row = await toggleProgress(
-		ctx.locals.db,
-		session.user.id,
-		body.slug,
-		body.completed,
-	)
+	let body: unknown
+	try {
+		body = await ctx.request.json()
+	} catch {
+		return new Response('Invalid JSON', { status: 400 })
+	}
 
-	return Response.json(row)
+	if (!isProgressBody(body)) {
+		return new Response('Invalid body', { status: 400 })
+	}
+
+	try {
+		const row = await toggleProgress(
+			ctx.locals.db,
+			session.user.id,
+			body.slug,
+			body.completed,
+		)
+		return Response.json(row)
+	} catch (err) {
+		console.error('[progress]', err)
+		return new Response('Internal error', { status: 500 })
+	}
 }

--- a/src/plugins/starlight-cloudflare-compat.ts
+++ b/src/plugins/starlight-cloudflare-compat.ts
@@ -1,36 +1,51 @@
 /**
- * Workaround for Starlight + Cloudflare adapter dev mode incompatibility.
+ * Workarounds for Starlight + Cloudflare adapter dev mode.
  *
- * The Cloudflare adapter runs SSR inside workerd and pre-bundles dependencies
- * via Vite's `configEnvironment` hook. It excludes `virtual:@astrojs/*` from
- * the optimizer, but Starlight registers its virtual modules under a different
- * namespace (`virtual:starlight/*`). When the optimizer tries to bundle
- * `@astrojs/starlight/locals`, it fails because it can't resolve the
- * `virtual:starlight/*` imports that only exist at runtime.
+ * 1. Starlight virtual modules (`virtual:starlight/*`) aren't excluded from
+ *    the SSR/prerender optimizer — add them manually.
+ *    @see https://github.com/withastro/starlight/issues/2875
  *
- * This plugin adds the missing exclusions to the SSR and prerender
- * environments. Build is unaffected — only dev mode triggers the issue.
+ * 2. `cloudflare:workers` is only available in the workerd runtime. The
+ *    prerender environment (Node.js) can't resolve it, so we stub it with
+ *    an empty `env` — the middleware safely skips D1/auth setup when `env.DB`
+ *    is undefined.
  *
  * Remove once fixed upstream in Starlight or the Cloudflare adapter.
- *
- * @see https://github.com/withastro/starlight/issues/2875
  */
+
+const STUB_ID = '\0cloudflare-workers-stub'
+
 export function starlightCloudflareCompat() {
-	return {
-		name: 'starlight-cloudflare-compat',
-		configEnvironment(
-			name: string,
-			options: { optimizeDeps?: { exclude?: string[] } },
-		) {
-			if (['ssr', 'prerender'].includes(name)) {
-				options.optimizeDeps ??= {}
-				options.optimizeDeps.exclude ??= []
-				options.optimizeDeps.exclude.push(
-					'virtual:starlight/*',
-					'@astrojs/starlight',
-					'@astrojs/starlight/locals',
-				)
-			}
+	return [
+		{
+			name: 'starlight-cloudflare-compat:optimize-deps',
+			configEnvironment(
+				name: string,
+				options: { optimizeDeps?: { exclude?: string[] } },
+			) {
+				if (['ssr', 'prerender'].includes(name)) {
+					options.optimizeDeps ??= {}
+					options.optimizeDeps.exclude ??= []
+					options.optimizeDeps.exclude.push(
+						'virtual:starlight/*',
+						'@astrojs/starlight',
+						'@astrojs/starlight/locals',
+					)
+				}
+			},
 		},
-	}
+		{
+			name: 'starlight-cloudflare-compat:prerender-stub',
+			enforce: 'pre' as const,
+			applyToEnvironment(env: { name: string }) {
+				return env.name === 'prerender'
+			},
+			resolveId(id: string) {
+				if (id === 'cloudflare:workers') return STUB_ID
+			},
+			load(id: string) {
+				if (id === STUB_ID) return 'export const env = {};'
+			},
+		},
+	]
 }

--- a/src/plugins/starlight-cloudflare-compat.ts
+++ b/src/plugins/starlight-cloudflare-compat.ts
@@ -1,0 +1,36 @@
+/**
+ * Workaround for Starlight + Cloudflare adapter dev mode incompatibility.
+ *
+ * The Cloudflare adapter runs SSR inside workerd and pre-bundles dependencies
+ * via Vite's `configEnvironment` hook. It excludes `virtual:@astrojs/*` from
+ * the optimizer, but Starlight registers its virtual modules under a different
+ * namespace (`virtual:starlight/*`). When the optimizer tries to bundle
+ * `@astrojs/starlight/locals`, it fails because it can't resolve the
+ * `virtual:starlight/*` imports that only exist at runtime.
+ *
+ * This plugin adds the missing exclusions to the SSR and prerender
+ * environments. Build is unaffected — only dev mode triggers the issue.
+ *
+ * Remove once fixed upstream in Starlight or the Cloudflare adapter.
+ *
+ * @see https://github.com/withastro/starlight/issues/2875
+ */
+export function starlightCloudflareCompat() {
+	return {
+		name: 'starlight-cloudflare-compat',
+		configEnvironment(
+			name: string,
+			options: { optimizeDeps?: { exclude?: string[] } },
+		) {
+			if (['ssr', 'prerender'].includes(name)) {
+				options.optimizeDeps ??= {}
+				options.optimizeDeps.exclude ??= []
+				options.optimizeDeps.exclude.push(
+					'virtual:starlight/*',
+					'@astrojs/starlight',
+					'@astrojs/starlight/locals',
+				)
+			}
+		},
+	}
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,13 +23,17 @@ tests/
 │   ├── topics.test.ts            # parseTopics, formatTopicNumber, topicLabel
 │   ├── href.test.ts              # topicHref link generation
 │   ├── sidebar.test.ts           # findGroupBySlug, getSubAreaSlugs
-│   ├── card-view.test.tsx        # topic card grid
-│   ├── table-view.test.tsx       # topic table with grade columns
+│   ├── card-view.test.tsx        # topic card grid + completion indicators
+│   ├── table-view.test.tsx       # topic table with grade columns + checkboxes
 │   ├── grade-filter.test.tsx     # grade radio group
 │   ├── view-toggle.test.tsx      # cards/table toggle
-│   └── subject-overview.test.tsx # integration: composition, localStorage, state
+│   ├── subject-overview.test.tsx # integration: composition, localStorage, progress
+│   ├── progress.test.ts          # progress API (GET/POST), progressSlug, isTopicCompleted
+│   ├── toast.test.tsx            # toast notifications
+│   └── user-menu.test.tsx        # sign-in/sign-out UI
 └── e2e/
-    └── subject-overview.spec.ts  # hydration, persistence, navigation
+    ├── subject-overview.spec.ts  # hydration, persistence, navigation
+    └── progress.spec.ts          # auth, checkboxes, error toasts
 ```
 
 ## 🧪 Unit Test Notes

--- a/tests/e2e/progress.spec.ts
+++ b/tests/e2e/progress.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test'
+
+async function mockAuthenticatedSession(
+	page: import('@playwright/test').Page,
+	progress: Record<string, boolean> = {},
+) {
+	await page.route('**/api/auth/get-session', (route) =>
+		route.fulfill({
+			contentType: 'application/json',
+			body: JSON.stringify({
+				session: { id: 's1', userId: 'u1' },
+				user: { id: 'u1', name: 'Test User', email: 'test@example.com' },
+			}),
+		}),
+	)
+	await page.route('**/api/progress?**', (route) =>
+		route.fulfill({
+			contentType: 'application/json',
+			body: JSON.stringify(progress),
+		}),
+	)
+}
+
+test('unauthenticated: no progress indicators', async ({ page }) => {
+	await page.goto('/matematika/')
+	await expect(page.getByTestId('card-view')).toBeVisible()
+
+	// No checkmarks or checkboxes
+	await expect(page.getByRole('img', { name: /hotovo/i })).toHaveCount(0)
+	await expect(page.getByRole('checkbox')).toHaveCount(0)
+})
+
+test('authenticated: card view shows completion checkmarks', async ({
+	page,
+}) => {
+	await mockAuthenticatedSession(page, {
+		'matematika/01-pocetni-operace/6-rocnik': true,
+		'matematika/01-pocetni-operace/7-rocnik': true,
+		'matematika/01-pocetni-operace/8-rocnik': true,
+		'matematika/01-pocetni-operace/9-rocnik': true,
+	})
+
+	await page.goto('/matematika/')
+	await expect(page.getByTestId('card-view')).toBeVisible()
+	await expect(page.getByRole('img', { name: /hotovo/i })).toHaveCount(1)
+})
+
+test('authenticated: table view shows checkboxes', async ({ page }) => {
+	await mockAuthenticatedSession(page)
+
+	await page.goto('/matematika/')
+	await page
+		.getByRole('group', { name: 'Zobrazení' })
+		.getByText('Tabulka')
+		.click()
+	await expect(page.getByTestId('table-view')).toBeVisible()
+
+	const checkboxes = page.getByRole('checkbox')
+	await expect(checkboxes.first()).toBeVisible()
+	expect(await checkboxes.count()).toBeGreaterThan(0)
+})
+
+test('toggle checkbox sends POST to progress API', async ({ page }) => {
+	await mockAuthenticatedSession(page)
+
+	let postBody: Record<string, unknown> | null = null
+	await page.route('**/api/progress', (route) => {
+		if (route.request().method() === 'POST') {
+			postBody = route.request().postDataJSON()
+			return route.fulfill({
+				contentType: 'application/json',
+				body: JSON.stringify({ ...postBody, id: '1', userId: 'u1' }),
+			})
+		}
+		return route.continue()
+	})
+
+	await page.goto('/matematika/')
+	await page
+		.getByRole('group', { name: 'Zobrazení' })
+		.getByText('Tabulka')
+		.click()
+	await expect(page.getByTestId('table-view')).toBeVisible()
+
+	const checkbox = page.getByRole('checkbox').first()
+	await checkbox.click()
+
+	await expect.poll(() => postBody).toBeTruthy()
+	expect(postBody).toHaveProperty('slug')
+	expect(postBody).toHaveProperty('completed', true)
+})
+
+test('API error shows toast notification', async ({ page }) => {
+	await mockAuthenticatedSession(page)
+
+	await page.route('**/api/progress', (route) => {
+		if (route.request().method() === 'POST') {
+			return route.fulfill({ status: 500, body: 'Internal Server Error' })
+		}
+		return route.continue()
+	})
+
+	await page.goto('/matematika/')
+	await page
+		.getByRole('group', { name: 'Zobrazení' })
+		.getByText('Tabulka')
+		.click()
+	await expect(page.getByTestId('table-view')).toBeVisible()
+
+	const checkbox = page.getByRole('checkbox').first()
+	await checkbox.click()
+
+	await expect(page.getByRole('alert')).toBeVisible()
+})

--- a/tests/e2e/progress.spec.ts
+++ b/tests/e2e/progress.spec.ts
@@ -112,3 +112,28 @@ test('API error shows toast notification', async ({ page }) => {
 
 	await expect(page.getByRole('alert')).toBeVisible()
 })
+
+test('401 error shows session-expired toast', async ({ page }) => {
+	await mockAuthenticatedSession(page)
+
+	await page.route('**/api/progress', (route) => {
+		if (route.request().method() === 'POST') {
+			return route.fulfill({ status: 401, body: 'Unauthorized' })
+		}
+		return route.continue()
+	})
+
+	await page.goto('/matematika/')
+	await page
+		.getByRole('group', { name: 'Zobrazení' })
+		.getByText('Tabulka')
+		.click()
+	await expect(page.getByTestId('table-view')).toBeVisible()
+
+	const checkbox = page.getByRole('checkbox').first()
+	await checkbox.click()
+
+	const alert = page.getByRole('alert')
+	await expect(alert).toBeVisible()
+	await expect(alert).toContainText('Přihlášení vypršelo')
+})

--- a/tests/unit/card-view.test.tsx
+++ b/tests/unit/card-view.test.tsx
@@ -23,10 +23,22 @@ const TOPICS: Topic[] = [
 
 const SUBJECT = 'matematika'
 
-function renderCardView(topics: Topic[], subject: string, initial: Grade) {
+function renderCardView(
+	topics: Topic[],
+	subject: string,
+	initial: Grade,
+	progress?: Record<string, boolean>,
+) {
 	const [grade, setGrade] = createSignal<Grade>(initial)
 
-	render(() => <CardView topics={topics} subject={subject} grade={grade()} />)
+	render(() => (
+		<CardView
+			topics={topics}
+			subject={subject}
+			grade={grade()}
+			progress={progress}
+		/>
+	))
 
 	return { setGrade }
 }
@@ -109,5 +121,80 @@ describe('CardView', () => {
 		const links = screen.getAllByRole('link')
 		expect(links[0].textContent).toContain('01.')
 		expect(links[1].textContent).toContain('02.')
+	})
+
+	test('shows no completion indicators when progress is undefined', () => {
+		renderCardView(TOPICS, SUBJECT, 'all')
+
+		expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(0)
+	})
+
+	test('shows completion indicator for completed topic', () => {
+		renderCardView(TOPICS, SUBJECT, '6', {
+			'matematika/01-pocetni-operace/6-rocnik': true,
+		})
+
+		expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(1)
+	})
+
+	test('hides completion indicator for incomplete topic', () => {
+		renderCardView(TOPICS, SUBJECT, '6', {
+			'matematika/01-pocetni-operace/6-rocnik': false,
+		})
+
+		expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(0)
+	})
+
+	test('shows completion indicator for "all" only when every grade is completed', () => {
+		renderCardView(TOPICS, SUBJECT, 'all', {
+			'matematika/01-pocetni-operace/6-rocnik': true,
+			'matematika/01-pocetni-operace/7-rocnik': true,
+			'matematika/01-pocetni-operace/8-rocnik': true,
+			'matematika/01-pocetni-operace/9-rocnik': true,
+		})
+
+		expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(1)
+	})
+
+	test('hides completion indicator for "all" when any grade is incomplete', () => {
+		renderCardView(TOPICS, SUBJECT, 'all', {
+			'matematika/01-pocetni-operace/6-rocnik': true,
+			'matematika/01-pocetni-operace/7-rocnik': false,
+			'matematika/01-pocetni-operace/8-rocnik': true,
+			'matematika/01-pocetni-operace/9-rocnik': true,
+		})
+
+		expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(0)
+	})
+
+	test('shows checkmarks only for completed topics in mixed set', () => {
+		renderCardView(TOPICS, SUBJECT, '6', {
+			'matematika/01-pocetni-operace/6-rocnik': true,
+			'matematika/02-zaokrouhlovani-a-odhady/6-rocnik': false,
+		})
+
+		expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(1)
+	})
+
+	test('muted cards show no completion indicator', () => {
+		// Topic 02 has grades [6,7] — grade 8 makes it muted
+		renderCardView(TOPICS, SUBJECT, '8', {
+			'matematika/02-zaokrouhlovani-a-odhady/8-rocnik': true,
+		})
+
+		expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(0)
+	})
+
+	test('completion indicator updates when grade changes', () => {
+		const { setGrade } = renderCardView(TOPICS, SUBJECT, '6', {
+			'matematika/01-pocetni-operace/6-rocnik': true,
+			'matematika/01-pocetni-operace/7-rocnik': false,
+		})
+
+		expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(1)
+
+		setGrade('7')
+
+		expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(0)
 	})
 })

--- a/tests/unit/progress.test.ts
+++ b/tests/unit/progress.test.ts
@@ -27,6 +27,68 @@ describe('Progress API', () => {
 		expect(response.status).toBe(401)
 	})
 
+	test('GET returns 400 for invalid subject format', async () => {
+		const mockAuth = {
+			api: {
+				getSession: () => Promise.resolve({ user: { id: 'user-1' } }),
+			},
+		}
+
+		const response = await GET(
+			mockCtx({
+				auth: mockAuth,
+				db: {},
+				url: new URL('http://localhost/api/progress?subject=../../x'),
+			}),
+		)
+
+		expect(response.status).toBe(400)
+	})
+
+	test('GET returns 400 for invalid grade format', async () => {
+		const mockAuth = {
+			api: {
+				getSession: () => Promise.resolve({ user: { id: 'user-1' } }),
+			},
+		}
+
+		const response = await GET(
+			mockCtx({
+				auth: mockAuth,
+				db: {},
+				url: new URL(
+					'http://localhost/api/progress?subject=matematika&grade=../../x',
+				),
+			}),
+		)
+
+		expect(response.status).toBe(400)
+	})
+
+	test('GET returns 500 on DB error', async () => {
+		const mockAuth = {
+			api: {
+				getSession: () => Promise.resolve({ user: { id: 'user-1' } }),
+			},
+		}
+		const mockDb = {
+			select: () => ({
+				from: () => ({
+					where: () => Promise.reject(new Error('DB error')),
+				}),
+			}),
+		}
+
+		const response = await GET(
+			mockCtx({
+				auth: mockAuth,
+				db: mockDb,
+			}),
+		)
+
+		expect(response.status).toBe(500)
+	})
+
 	test('GET returns progress map for subject', async () => {
 		const mockDb = {
 			select: () => ({
@@ -102,6 +164,87 @@ describe('Progress API', () => {
 		)
 
 		expect(response.status).toBe(401)
+	})
+
+	test('POST returns 400 for malformed JSON body', async () => {
+		const mockAuth = {
+			api: {
+				getSession: () => Promise.resolve({ user: { id: 'user-1' } }),
+			},
+		}
+
+		const response = await POST(
+			mockCtx({
+				auth: mockAuth,
+				db: {},
+				request: new Request('http://localhost/api/progress', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: 'not-json',
+				}),
+			}),
+		)
+
+		expect(response.status).toBe(400)
+	})
+
+	test('POST returns 400 for invalid body', async () => {
+		const mockAuth = {
+			api: {
+				getSession: () => Promise.resolve({ user: { id: 'user-1' } }),
+			},
+		}
+
+		const response = await POST(
+			mockCtx({
+				auth: mockAuth,
+				db: {},
+				request: new Request('http://localhost/api/progress', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						slug: '../../etc/passwd',
+						completed: true,
+					}),
+				}),
+			}),
+		)
+
+		expect(response.status).toBe(400)
+	})
+
+	test('POST returns 500 on DB error', async () => {
+		const mockAuth = {
+			api: {
+				getSession: () => Promise.resolve({ user: { id: 'user-1' } }),
+			},
+		}
+		const mockDb = {
+			insert: () => ({
+				values: () => ({
+					onConflictDoUpdate: () => ({
+						returning: () => Promise.reject(new Error('DB error')),
+					}),
+				}),
+			}),
+		}
+
+		const response = await POST(
+			mockCtx({
+				auth: mockAuth,
+				db: mockDb,
+				request: new Request('http://localhost/api/progress', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						slug: 'matematika/01-pocetni-operace/6-rocnik',
+						completed: true,
+					}),
+				}),
+			}),
+		)
+
+		expect(response.status).toBe(500)
 	})
 
 	test('POST upserts progress entry', async () => {

--- a/tests/unit/progress.test.ts
+++ b/tests/unit/progress.test.ts
@@ -148,3 +148,55 @@ describe('Progress API', () => {
 		expect(data.completed).toBe(true)
 	})
 })
+
+describe('progressSlug', () => {
+	test('constructs slug from subject, topic, and grade', async () => {
+		const { progressSlug } = await import('@/lib/progress')
+
+		expect(progressSlug('matematika', '01-pocetni-operace', '6-rocnik')).toBe(
+			'matematika/01-pocetni-operace/6-rocnik',
+		)
+	})
+})
+
+describe('isTopicCompleted', () => {
+	test('returns true when specific grade is completed', async () => {
+		const { isTopicCompleted } = await import('@/lib/progress')
+
+		const progress = { 'matematika/01/6-rocnik': true }
+
+		expect(
+			isTopicCompleted(progress, 'matematika', '01', '6-rocnik', [6, 7, 8, 9]),
+		).toBe(true)
+	})
+
+	test('returns true for "all" when every grade is completed', async () => {
+		const { isTopicCompleted } = await import('@/lib/progress')
+
+		const progress = {
+			'matematika/01/6-rocnik': true,
+			'matematika/01/7-rocnik': true,
+			'matematika/01/8-rocnik': true,
+			'matematika/01/9-rocnik': true,
+		}
+
+		expect(
+			isTopicCompleted(progress, 'matematika', '01', 'all', [6, 7, 8, 9]),
+		).toBe(true)
+	})
+
+	test('returns false for "all" when any grade is incomplete', async () => {
+		const { isTopicCompleted } = await import('@/lib/progress')
+
+		const progress = {
+			'matematika/01/6-rocnik': true,
+			'matematika/01/7-rocnik': false,
+			'matematika/01/8-rocnik': true,
+			'matematika/01/9-rocnik': true,
+		}
+
+		expect(
+			isTopicCompleted(progress, 'matematika', '01', 'all', [6, 7, 8, 9]),
+		).toBe(false)
+	})
+})

--- a/tests/unit/progress.test.ts
+++ b/tests/unit/progress.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test, vi } from 'vitest'
+import { GET, POST } from '@/pages/api/progress'
+
+function mockCtx({
+	auth,
+	db,
+	request,
+	url,
+}: {
+	auth?: unknown
+	db?: unknown
+	request?: Request
+	url?: URL
+} = {}) {
+	const defaultUrl = 'http://localhost/api/progress?subject=matematika'
+	return {
+		locals: { auth, db },
+		request: request ?? new Request(defaultUrl),
+		url: url ?? new URL(defaultUrl),
+	} as Parameters<typeof GET>[0]
+}
+
+describe('Progress API', () => {
+	test('GET returns 401 when unauthenticated', async () => {
+		const response = await GET(mockCtx())
+
+		expect(response.status).toBe(401)
+	})
+
+	test('GET returns progress map for subject', async () => {
+		const mockDb = {
+			select: () => ({
+				from: () => ({
+					where: () =>
+						Promise.resolve([
+							{ slug: 'matematika/01/6-rocnik', completed: true },
+							{ slug: 'matematika/02/6-rocnik', completed: false },
+						]),
+				}),
+			}),
+		}
+		const mockAuth = {
+			api: {
+				getSession: () => Promise.resolve({ user: { id: 'user-1' } }),
+			},
+		}
+
+		const response = await GET(
+			mockCtx({
+				auth: mockAuth,
+				db: mockDb,
+			}),
+		)
+		const data = await response.json()
+
+		expect(response.status).toBe(200)
+		expect(data).toEqual({
+			'matematika/01/6-rocnik': true,
+			'matematika/02/6-rocnik': false,
+		})
+	})
+
+	test('GET filters by grade when provided', async () => {
+		const whereFn = vi.fn(() =>
+			Promise.resolve([{ slug: 'matematika/01/7-rocnik', completed: true }]),
+		)
+		const mockDb = {
+			select: () => ({ from: () => ({ where: whereFn }) }),
+		}
+		const mockAuth = {
+			api: {
+				getSession: () => Promise.resolve({ user: { id: 'user-1' } }),
+			},
+		}
+
+		const response = await GET(
+			mockCtx({
+				auth: mockAuth,
+				db: mockDb,
+				url: new URL(
+					'http://localhost/api/progress?subject=matematika&grade=7-rocnik',
+				),
+			}),
+		)
+		const data = await response.json()
+
+		expect(response.status).toBe(200)
+		expect(data).toEqual({ 'matematika/01/7-rocnik': true })
+	})
+
+	test('POST returns 401 when unauthenticated', async () => {
+		const response = await POST(
+			mockCtx({
+				request: new Request('http://localhost/api/progress', {
+					method: 'POST',
+					body: JSON.stringify({
+						slug: 'matematika/01/6-rocnik',
+						completed: true,
+					}),
+				}),
+			}),
+		)
+
+		expect(response.status).toBe(401)
+	})
+
+	test('POST upserts progress entry', async () => {
+		const insertedRow = {
+			id: 'abc',
+			userId: 'user-1',
+			slug: 'matematika/01/6-rocnik',
+			completed: true,
+			updatedAt: new Date(),
+		}
+		const mockDb = {
+			insert: () => ({
+				values: () => ({
+					onConflictDoUpdate: () => ({
+						returning: () => Promise.resolve([insertedRow]),
+					}),
+				}),
+			}),
+		}
+		const mockAuth = {
+			api: {
+				getSession: () => Promise.resolve({ user: { id: 'user-1' } }),
+			},
+		}
+
+		const response = await POST(
+			mockCtx({
+				auth: mockAuth,
+				db: mockDb,
+				request: new Request('http://localhost/api/progress', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						slug: 'matematika/01/6-rocnik',
+						completed: true,
+					}),
+				}),
+			}),
+		)
+		const data = await response.json()
+
+		expect(response.status).toBe(200)
+		expect(data.slug).toBe('matematika/01/6-rocnik')
+		expect(data.completed).toBe(true)
+	})
+})

--- a/tests/unit/subject-overview.test.tsx
+++ b/tests/unit/subject-overview.test.tsx
@@ -15,6 +15,15 @@ let mockSession: { user: { name: string } } | null = null
 let mockProgressData: Record<string, boolean> | undefined
 const mockMutateAsync = vi.fn().mockResolvedValue({})
 
+// ProgressError from the original (non-mocked) module for instanceof checks.
+class ProgressError extends Error {
+	status: number
+	constructor(status: number, message: string) {
+		super(message)
+		this.status = status
+	}
+}
+
 vi.mock('@/lib/auth-client', () => ({
 	authClient: {
 		useSession: () => () => ({
@@ -288,6 +297,25 @@ describe('SubjectOverview', () => {
 
 			await waitFor(() => {
 				expect(screen.getByRole('alert')).toBeDefined()
+			})
+		})
+
+		test('shows session-expired toast on 401 error', async () => {
+			mockSession = { user: { name: 'Test' } }
+			mockProgressData = {}
+			mockMutateAsync.mockRejectedValue(new ProgressError(401, 'HTTP 401'))
+
+			renderOverview()
+			fireEvent.click(screen.getByRole('radio', { name: 'Tabulka' }))
+
+			const checkbox = screen.getByRole('checkbox', {
+				name: '01. Početní operace s celými a racionálními čísly, 6. ročník',
+			})
+			fireEvent.click(checkbox)
+
+			await waitFor(() => {
+				const alert = screen.getByRole('alert')
+				expect(alert.textContent).toContain('Přihlášení vypršelo')
 			})
 		})
 	})

--- a/tests/unit/subject-overview.test.tsx
+++ b/tests/unit/subject-overview.test.tsx
@@ -300,6 +300,31 @@ describe('SubjectOverview', () => {
 			})
 		})
 
+		test('shows toast when user goes offline', async () => {
+			renderOverview()
+
+			window.dispatchEvent(new Event('offline'))
+
+			await waitFor(() => {
+				const alert = screen.getByRole('alert')
+				expect(alert.textContent).toContain('Jste offline')
+			})
+		})
+
+		test('dismisses toast when user comes back online', async () => {
+			renderOverview()
+
+			window.dispatchEvent(new Event('offline'))
+			await waitFor(() => {
+				expect(screen.getByRole('alert')).toBeDefined()
+			})
+
+			window.dispatchEvent(new Event('online'))
+			await waitFor(() => {
+				expect(screen.queryByRole('alert')).toBeNull()
+			})
+		})
+
 		test('shows session-expired toast on 401 error', async () => {
 			mockSession = { user: { name: 'Test' } }
 			mockProgressData = {}

--- a/tests/unit/subject-overview.test.tsx
+++ b/tests/unit/subject-overview.test.tsx
@@ -1,9 +1,44 @@
-import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@solidjs/testing-library'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { GRADE_STORAGE_KEY } from '@/components/grade-filter/grade'
 import SubjectOverview from '@/components/subject-overview/SubjectOverview'
 import { VIEW_STORAGE_KEY } from '@/components/view-toggle/view'
 import type { Topic } from '@/lib/topics'
+
+let mockSession: { user: { name: string } } | null = null
+let mockProgressData: Record<string, boolean> | undefined
+const mockMutateAsync = vi.fn().mockResolvedValue({})
+
+vi.mock('@/lib/auth-client', () => ({
+	authClient: {
+		useSession: () => () => ({
+			data: mockSession,
+			isPending: false,
+		}),
+	},
+}))
+
+vi.mock('@/lib/progress-hooks', () => ({
+	createProgressQuery: () => ({
+		get data() {
+			return mockProgressData
+		},
+		isLoading: false,
+		isError: false,
+	}),
+	createProgressMutation: () => ({
+		mutate: vi.fn(),
+		mutateAsync: mockMutateAsync,
+		isError: false,
+		isPending: false,
+	}),
+}))
 
 const TOPICS: Topic[] = [
 	{
@@ -31,6 +66,9 @@ describe('SubjectOverview', () => {
 	afterEach(() => {
 		cleanup()
 		localStorage.clear()
+		mockSession = null
+		mockProgressData = undefined
+		mockMutateAsync.mockReset().mockResolvedValue({})
 	})
 
 	describe('composition', () => {
@@ -180,6 +218,77 @@ describe('SubjectOverview', () => {
 				VIEW_STORAGE_KEY,
 				'table',
 			)
+		})
+	})
+
+	describe('progress tracking', () => {
+		test('shows checkmarks when authenticated with progress data', () => {
+			mockSession = { user: { name: 'Test' } }
+			mockProgressData = {
+				'matematika/01-pocetni-operace/6-rocnik': true,
+				'matematika/01-pocetni-operace/7-rocnik': true,
+				'matematika/01-pocetni-operace/8-rocnik': true,
+				'matematika/01-pocetni-operace/9-rocnik': true,
+			}
+
+			renderOverview()
+
+			expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(1)
+		})
+
+		test('shows no checkmarks when unauthenticated', () => {
+			mockSession = null
+			mockProgressData = undefined
+
+			renderOverview()
+
+			expect(screen.queryAllByRole('img', { name: /hotovo/i })).toHaveLength(0)
+		})
+
+		test('table view shows checkboxes when authenticated', () => {
+			mockSession = { user: { name: 'Test' } }
+			mockProgressData = {}
+
+			renderOverview()
+			fireEvent.click(screen.getByRole('radio', { name: 'Tabulka' }))
+
+			expect(screen.getAllByRole('checkbox')).toHaveLength(6)
+		})
+
+		test('clicking table checkbox calls mutation', () => {
+			mockSession = { user: { name: 'Test' } }
+			mockProgressData = {}
+
+			renderOverview()
+			fireEvent.click(screen.getByRole('radio', { name: 'Tabulka' }))
+
+			const checkbox = screen.getByRole('checkbox', {
+				name: '01. Početní operace s celými a racionálními čísly, 6. ročník',
+			})
+			fireEvent.click(checkbox)
+
+			expect(mockMutateAsync).toHaveBeenCalledWith({
+				slug: 'matematika/01-pocetni-operace/6-rocnik',
+				completed: true,
+			})
+		})
+
+		test('shows toast on mutation error', async () => {
+			mockSession = { user: { name: 'Test' } }
+			mockProgressData = {}
+			mockMutateAsync.mockRejectedValue(new Error('Network error'))
+
+			renderOverview()
+			fireEvent.click(screen.getByRole('radio', { name: 'Tabulka' }))
+
+			const checkbox = screen.getByRole('checkbox', {
+				name: '01. Početní operace s celými a racionálními čísly, 6. ročník',
+			})
+			fireEvent.click(checkbox)
+
+			await waitFor(() => {
+				expect(screen.getByRole('alert')).toBeDefined()
+			})
 		})
 	})
 })

--- a/tests/unit/table-view.test.tsx
+++ b/tests/unit/table-view.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup, render, screen } from '@solidjs/testing-library'
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { Grade } from '@/components/grade-filter/grade'
 import TableView from '@/components/table-view/TableView'
 import type { Topic } from '@/lib/topics'
@@ -23,10 +23,26 @@ const TOPICS: Topic[] = [
 
 const SUBJECT = 'matematika'
 
-function renderTableView(topics: Topic[], subject: string, initial: Grade) {
+function renderTableView(
+	topics: Topic[],
+	subject: string,
+	initial: Grade,
+	options?: {
+		progress?: Record<string, boolean>
+		onToggle?: (slug: string, completed: boolean) => void
+	},
+) {
 	const [grade, setGrade] = createSignal<Grade>(initial)
 
-	render(() => <TableView topics={topics} subject={subject} grade={grade()} />)
+	render(() => (
+		<TableView
+			topics={topics}
+			subject={subject}
+			grade={grade()}
+			progress={options?.progress}
+			onToggle={options?.onToggle}
+		/>
+	))
 
 	return { setGrade }
 }
@@ -153,6 +169,132 @@ describe('TableView', () => {
 		// Grade 6 should not be muted
 		const grade6Cells = table.querySelectorAll('[data-grade="6"]')
 		for (const cell of grade6Cells) {
+			expect(cell.hasAttribute('data-muted')).toBe(false)
+		}
+	})
+
+	// --- Progress checkboxes ---
+
+	test('shows no checkboxes when progress is undefined', () => {
+		renderTableView(TOPICS, SUBJECT, 'all')
+
+		expect(screen.queryAllByRole('checkbox')).toHaveLength(0)
+	})
+
+	test('renders checkboxes in available grade cells when progress provided', () => {
+		renderTableView(TOPICS, SUBJECT, 'all', { progress: {} })
+
+		// Topic 1: 4 grades + Topic 2: 2 grades = 6 checkboxes
+		expect(screen.getAllByRole('checkbox')).toHaveLength(6)
+	})
+
+	test('checkbox is checked when progress entry is true', () => {
+		renderTableView(TOPICS, SUBJECT, 'all', {
+			progress: { 'matematika/01-pocetni-operace/6-rocnik': true },
+		})
+
+		const checkbox = screen.getByRole('checkbox', {
+			name: '01. Početní operace s celými a racionálními čísly, 6. ročník',
+		})
+		expect((checkbox as HTMLInputElement).checked).toBe(true)
+	})
+
+	test('checkbox is unchecked when progress entry is false or missing', () => {
+		renderTableView(TOPICS, SUBJECT, 'all', {
+			progress: { 'matematika/01-pocetni-operace/6-rocnik': false },
+		})
+
+		const checkbox = screen.getByRole('checkbox', {
+			name: '01. Početní operace s celými a racionálními čísly, 6. ročník',
+		})
+		expect((checkbox as HTMLInputElement).checked).toBe(false)
+
+		// Missing entry — also unchecked
+		const missing = screen.getByRole('checkbox', {
+			name: '01. Početní operace s celými a racionálními čísly, 7. ročník',
+		})
+		expect((missing as HTMLInputElement).checked).toBe(false)
+	})
+
+	test('each checkbox has descriptive aria-label', () => {
+		renderTableView(TOPICS, SUBJECT, 'all', { progress: {} })
+
+		expect(
+			screen.getByRole('checkbox', {
+				name: '01. Početní operace s celými a racionálními čísly, 6. ročník',
+			}),
+		).toBeDefined()
+		expect(
+			screen.getByRole('checkbox', {
+				name: '02. Zaokrouhlování a odhady, 7. ročník',
+			}),
+		).toBeDefined()
+	})
+
+	test('unavailable grade cells show em dash even when progress provided', () => {
+		renderTableView(TOPICS, SUBJECT, 'all', { progress: {} })
+
+		// Topic 2 has grades [6,7] — grades 8,9 still show "—"
+		const rows = screen.getAllByRole('row')
+		const gradeCells = rows[2].querySelectorAll('td[data-grade]')
+		expect(gradeCells[2].textContent).toBe('—')
+		expect(gradeCells[3].textContent).toBe('—')
+	})
+
+	test('clicking unchecked checkbox calls onToggle with slug and true', () => {
+		const onToggle = vi.fn()
+		renderTableView(TOPICS, SUBJECT, 'all', { progress: {}, onToggle })
+
+		const checkbox = screen.getByRole('checkbox', {
+			name: '01. Početní operace s celými a racionálními čísly, 6. ročník',
+		})
+		fireEvent.click(checkbox)
+
+		expect(onToggle).toHaveBeenCalledWith(
+			'matematika/01-pocetni-operace/6-rocnik',
+			true,
+		)
+	})
+
+	test('clicking checked checkbox calls onToggle with slug and false', () => {
+		const onToggle = vi.fn()
+		renderTableView(TOPICS, SUBJECT, 'all', {
+			progress: { 'matematika/01-pocetni-operace/6-rocnik': true },
+			onToggle,
+		})
+
+		const checkbox = screen.getByRole('checkbox', {
+			name: '01. Početní operace s celými a racionálními čísly, 6. ročník',
+		})
+		fireEvent.click(checkbox)
+
+		expect(onToggle).toHaveBeenCalledWith(
+			'matematika/01-pocetni-operace/6-rocnik',
+			false,
+		)
+	})
+
+	test('grade links still present alongside checkboxes', () => {
+		renderTableView(TOPICS, SUBJECT, 'all', { progress: {} })
+
+		const rows = screen.getAllByRole('row')
+		const topic1Links = rows[1].querySelectorAll('td[data-grade] a')
+		expect(topic1Links).toHaveLength(4)
+		expect(topic1Links[0].getAttribute('href')).toBe(
+			'/matematika/01-pocetni-operace/6-rocnik',
+		)
+	})
+
+	test('checkbox cells get data-muted for non-selected grades', () => {
+		renderTableView(TOPICS, SUBJECT, '7', { progress: {} })
+
+		const table = screen.getByRole('table')
+		const grade6Cells = table.querySelectorAll('[data-grade="6"]')
+		for (const cell of grade6Cells) {
+			expect(cell.hasAttribute('data-muted')).toBe(true)
+		}
+		const grade7Cells = table.querySelectorAll('[data-grade="7"]')
+		for (const cell of grade7Cells) {
 			expect(cell.hasAttribute('data-muted')).toBe(false)
 		}
 	})

--- a/tests/unit/toast.test.tsx
+++ b/tests/unit/toast.test.tsx
@@ -1,0 +1,47 @@
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@solidjs/testing-library'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import Toast from '@/components/toast/Toast'
+
+describe('Toast', () => {
+	afterEach(cleanup)
+
+	test('renders nothing when message is undefined', () => {
+		render(() => <Toast message={undefined} />)
+
+		expect(screen.queryByRole('alert')).toBeNull()
+	})
+
+	test('renders message with role="alert" and aria-live="polite"', () => {
+		render(() => <Toast message="Něco se pokazilo" />)
+
+		const alert = screen.getByRole('alert')
+		expect(alert.textContent).toContain('Něco se pokazilo')
+		expect(alert.getAttribute('aria-live')).toBe('polite')
+	})
+
+	test('calls onDismiss after duration', async () => {
+		const onDismiss = vi.fn()
+		render(() => <Toast message="Chyba" onDismiss={onDismiss} duration={50} />)
+
+		expect(onDismiss).not.toHaveBeenCalled()
+
+		await waitFor(() => {
+			expect(onDismiss).toHaveBeenCalledOnce()
+		})
+	})
+
+	test('clicking close button calls onDismiss', () => {
+		const onDismiss = vi.fn()
+		render(() => <Toast message="Chyba" onDismiss={onDismiss} />)
+
+		fireEvent.click(screen.getByRole('button', { name: /zavřít/i }))
+
+		expect(onDismiss).toHaveBeenCalledOnce()
+	})
+})

--- a/tests/unit/user-menu.test.tsx
+++ b/tests/unit/user-menu.test.tsx
@@ -11,8 +11,8 @@ vi.mock('@/lib/auth-client', () => ({
 			data: mockSession,
 			isPending: false,
 		}),
-		signIn: { social: vi.fn() },
-		signOut: vi.fn(),
+		signIn: { social: vi.fn().mockResolvedValue({}) },
+		signOut: vi.fn().mockResolvedValue({}),
 	},
 }))
 

--- a/tests/unit/user-menu.test.tsx
+++ b/tests/unit/user-menu.test.tsx
@@ -4,12 +4,14 @@ import UserMenu from '@/components/user-menu/UserMenu'
 import { authClient } from '@/lib/auth-client'
 
 let mockSession: { user: { name: string; image?: string } } | null = null
+let mockError: { status: number } | null = null
 
 vi.mock('@/lib/auth-client', () => ({
 	authClient: {
 		useSession: () => () => ({
 			data: mockSession,
 			isPending: false,
+			error: mockError,
 		}),
 		signIn: { social: vi.fn().mockResolvedValue({}) },
 		signOut: vi.fn().mockResolvedValue({}),
@@ -20,12 +22,21 @@ describe('UserMenu', () => {
 	afterEach(() => {
 		cleanup()
 		mockSession = null
+		mockError = null
 	})
 
 	test('renders sign-in button when unauthenticated', () => {
 		render(() => <UserMenu />)
 
 		expect(screen.getByRole('button', { name: 'Přihlásit se' })).toBeDefined()
+	})
+
+	test('hides sign-in button when auth is unavailable', () => {
+		mockError = { status: 503 }
+
+		render(() => <UserMenu />)
+
+		expect(screen.queryByRole('button', { name: 'Přihlásit se' })).toBeNull()
 	})
 
 	test('clicking sign-in triggers Google OAuth', () => {

--- a/tests/unit/user-menu.test.tsx
+++ b/tests/unit/user-menu.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import UserMenu from '@/components/user-menu/UserMenu'
+import { authClient } from '@/lib/auth-client'
+
+let mockSession: { user: { name: string; image?: string } } | null = null
+
+vi.mock('@/lib/auth-client', () => ({
+	authClient: {
+		useSession: () => () => ({
+			data: mockSession,
+			isPending: false,
+		}),
+		signIn: { social: vi.fn() },
+		signOut: vi.fn(),
+	},
+}))
+
+describe('UserMenu', () => {
+	afterEach(() => {
+		cleanup()
+		mockSession = null
+	})
+
+	test('renders sign-in button when unauthenticated', () => {
+		render(() => <UserMenu />)
+
+		expect(screen.getByRole('button', { name: 'Přihlásit se' })).toBeDefined()
+	})
+
+	test('clicking sign-in triggers Google OAuth', () => {
+		render(() => <UserMenu />)
+
+		fireEvent.click(screen.getByRole('button', { name: 'Přihlásit se' }))
+
+		expect(authClient.signIn.social).toHaveBeenCalledWith({
+			provider: 'google',
+		})
+	})
+
+	test('renders user name and sign-out when authenticated', () => {
+		mockSession = { user: { name: 'Jan Novák' } }
+
+		render(() => <UserMenu />)
+
+		expect(screen.getByText('Jan Novák')).toBeDefined()
+		expect(screen.getByRole('button', { name: 'Odhlásit' })).toBeDefined()
+	})
+
+	test('clicking sign-out triggers sign-out', () => {
+		mockSession = { user: { name: 'Jan Novák' } }
+
+		render(() => <UserMenu />)
+
+		fireEvent.click(screen.getByRole('button', { name: 'Odhlásit' }))
+
+		expect(authClient.signOut).toHaveBeenCalled()
+	})
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,7 +19,8 @@
 		{
 			"binding": "DB",
 			"database_name": "semafor-db",
-			"database_id": "9d034a54-9eb2-4f90-8a8f-7dd03f0c89ef"
+			"database_id": "9d034a54-9eb2-4f90-8a8f-7dd03f0c89ef",
+			"migrations_dir": "drizzle/migrations"
 		}
 	]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,9 +2,7 @@
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "semafor",
 	"compatibility_date": "2026-03-12",
-	"assets": {
-		"directory": "./dist"
-	},
+	"compatibility_flags": ["nodejs_compat"],
 	"observability": {
 		"enabled": true
 	},

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,14 @@
 		"enabled": true
 	},
 	"preview_urls": true,
+	// CF adapter auto-provisions Astro sessions via KV — binding defined
+	// here to prevent re-creation on deploy (we use Better Auth, not Astro sessions)
+	"kv_namespaces": [
+		{
+			"binding": "SESSION",
+			"id": "d396cf9e39924e89b471a4f99081eea1"
+		}
+	],
 	"d1_databases": [
 		{
 			"binding": "DB",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,5 +6,12 @@
 	"observability": {
 		"enabled": true
 	},
-	"preview_urls": true
+	"preview_urls": true,
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "semafor-db",
+			"database_id": "9d034a54-9eb2-4f90-8a8f-7dd03f0c89ef"
+		}
+	]
 }


### PR DESCRIPTION
Spec: `.claude/SPEC-PROGRESS-TRACKING.md`

## Summary

Per-user completion tracking on subject Přehled pages. Parents log in with Google, mark topic-grade pairs as completed via checkboxes (table view) or see indicators (card view). Data persisted in Cloudflare D1.

Closes #61, closes #47, closes #48, closes #49, closes #50, closes #51, closes #52, closes #53.

## Subtasks

- [x] #47 — Fix spec inaccuracies for Astro 6
- [x] #48 — Cloudflare adapter + server output mode
- [x] #49 — D1 database + Drizzle schema
- [x] #50 — Better Auth server config + auth API route
- [x] #51 — TanStack Query setup
- [x] #52 — Auth client + UserMenu (TDD)
- [x] #53 — Progress API route (TDD)
- [x] #54 — Progress hooks — query + mutation (TDD)
- [x] #55 — CardView completion indicators (TDD)
- [x] #56 — TableView checkboxes (TDD)
- [x] #57 — Toast component (TDD)
- [x] #58 — SubjectOverview integration (TDD)
- [x] #59 — E2E tests
- [ ] #60 — Final spec + docs update
- [ ] #70 — Style review + polish
- [x] #71 — Login button only when auth available
- [x] #72 — User goes offline notification

## Test plan

- [ ] `pnpm type.check` passes
- [ ] `pnpm lint.write` passes
- [ ] `pnpm build` passes
- [ ] All unit and integration tests pass
- [ ] E2E tests pass